### PR TITLE
Release 2.8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+rules/report_generation/scripts/__pycache__

--- a/envs/containers/envs.yml
+++ b/envs/containers/envs.yml
@@ -3,12 +3,12 @@ blast: docker://quay.io/biocontainers/blast:2.9.0--pl526h3066fca_4
 spades: docker://quay.io/biocontainers/spades:3.15.4--h95f258a_0
 vt: docker://quay.io/biocontainers/vt:0.57721--hdf88d34_2
 bcftools: docker://quay.io/biocontainers/bcftools:1.9--h68d8f2e_7
-python_r: docker://metagenlab/python-r:1.2
+python_r: docker://metagenlab/diag-pipeline-python-r:1.2
 bedtools: docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0
 bwa_samtools: docker://metagenlab/bwa-samtools:1.0
 mykrobe: docker://quay.io/biocontainers/mykrobe:0.10.0--py39h98c8e45_0
 tb-profiler: docker://metagenlab/tb-profiler:3.0.8
-rgi: docker://metagenlab/rgi:5.2.1-3.2.2
+rgi: docker://quay.io/biocontainers/rgi:6.0.3--pyha8f3691_1
 pyvcf: docker://limr/pyvcf:0.6.8
 mentalist: docker://quay.io/biocontainers/mentalist:0.1.9--hbc14f71_4  
 entrez-direct: docker://quay.io/biocontainers/entrez-direct:13.9--pl526h375a9b1_0 #docker://metagenlab/entrez-direct:1.1

--- a/envs/containers/envs.yml
+++ b/envs/containers/envs.yml
@@ -15,7 +15,7 @@ entrez-direct: docker://quay.io/biocontainers/entrez-direct:13.9--pl526h375a9b1_
 freebayes: docker://quay.io/biocontainers/freebayes:1.3.1--py37h56106d0_0
 gatk4: docker://quay.io/biocontainers/gatk4:4.1.4.0--0
 mash: docker://quay.io/biocontainers/mash:2.2.1--h3d38be6_0
-checkm: docker://metagenlab/checkm:1.0.20
+checkm: docker://quay.io/biocontainers/checkm-genome:1.2.2--pyhdfd78af_1
 mafft: docker://quay.io/biocontainers/mafft:7.407--hf484d3e_2
 fasttree: docker://quay.io/biocontainers/fasttree:2.1.10--h14c3975_3
 newick_utils: docker://quay.io/biocontainers/newick_utils:1.6--h470a237_2

--- a/envs/containers/envs.yml
+++ b/envs/containers/envs.yml
@@ -3,7 +3,7 @@ blast: docker://quay.io/biocontainers/blast:2.9.0--pl526h3066fca_4
 spades: docker://quay.io/biocontainers/spades:3.15.4--h95f258a_0
 vt: docker://quay.io/biocontainers/vt:0.57721--hdf88d34_2
 bcftools: docker://quay.io/biocontainers/bcftools:1.9--h68d8f2e_7
-python_r: docker://metagenlab/diag-pipeline-python-r:1.1
+python_r: python-r.sif
 bedtools: docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0
 bwa_samtools: docker://metagenlab/bwa-samtools:1.0
 mykrobe: docker://quay.io/biocontainers/mykrobe:0.10.0--py39h98c8e45_0

--- a/envs/containers/envs.yml
+++ b/envs/containers/envs.yml
@@ -3,7 +3,7 @@ blast: docker://quay.io/biocontainers/blast:2.9.0--pl526h3066fca_4
 spades: docker://quay.io/biocontainers/spades:3.15.4--h95f258a_0
 vt: docker://quay.io/biocontainers/vt:0.57721--hdf88d34_2
 bcftools: docker://quay.io/biocontainers/bcftools:1.9--h68d8f2e_7
-python_r: python-r.sif
+python_r: docker://metagenlab/python-r:1.2
 bedtools: docker://quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0
 bwa_samtools: docker://metagenlab/bwa-samtools:1.0
 mykrobe: docker://quay.io/biocontainers/mykrobe:0.10.0--py39h98c8e45_0

--- a/rules/annotation/bakta.rules
+++ b/rules/annotation/bakta.rules
@@ -62,7 +62,7 @@ rule annotate_with_bakta_unfiltered_assembly:
     input:
         contigs = "samples/{sample}/assembly/spades_no_correction/contigs.fasta",
     params:
-	    database = "/data/databases/baktadb/db",
+	    database = config["bakta_db"],
     output:
         "samples/{sample}/annotation/spades_no_correction/{sample}.fsa"
     threads: 8

--- a/rules/annotation/bakta.rules
+++ b/rules/annotation/bakta.rules
@@ -16,7 +16,7 @@ def get_species(wildcards):
 
 rule annotate_with_bakta:
     container:
-        singularity_envs["bakta"]
+        containers["bakta"]
     input:
         contigs = "samples/{sample}/assembly/spades/coverage_filtered/bwa/contigs_500bp_high_coverage.fasta",
     threads: 8
@@ -42,7 +42,7 @@ rule annotate_with_bakta:
 
 rule get_plasmids_platon:
     container:
-        singularity_envs["platon"]
+        containers["platon"]
     input:
         contigs = "samples/{sample}/assembly/spades/coverage_filtered/bwa/contigs_500bp_high_coverage.fasta",
     params:
@@ -58,7 +58,7 @@ rule get_plasmids_platon:
 
 rule annotate_with_bakta_unfiltered_assembly:
     container:
-        singularity_envs["bakta"]
+        containers["bakta"]
     input:
         contigs = "samples/{sample}/assembly/spades_no_correction/contigs.fasta",
     params:
@@ -82,7 +82,7 @@ rule create_blast_database_from_protein_sequences:
     conda:
         "../../envs/blast.yml"
     container:
-        singularity_envs["blast"]
+        containers["blast"]
     input:
         proteins = "samples/{sample}/annotation/{sample}.faa",
     output:
@@ -96,7 +96,7 @@ rule create_blast_database_from_contig_sequences:
     conda:
         "../../envs/blast.yml"
     container:
-        singularity_envs["blast"]
+        containers["blast"]
     input:
         contigs = "samples/{sample}/annotation/{sample}.fna",
     output:
@@ -110,7 +110,7 @@ rule remove_fasta_part_from_gff:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         "samples/{sample}/annotation/{sample}.gff3"
     output:
@@ -122,7 +122,7 @@ rule get_CDS_and_contigs_depth:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         "samples/{sample}/assembly/spades/contigs_500bp_renamed.fasta",
         "samples/{sample}/annotation/{sample}.gbff",

--- a/rules/annotation/bakta.rules
+++ b/rules/annotation/bakta.rules
@@ -15,7 +15,7 @@ def get_species(wildcards):
 
 
 rule annotate_with_bakta:
-    singularity:
+    container:
         singularity_envs["bakta"]
     input:
         contigs = "samples/{sample}/assembly/spades/coverage_filtered/bwa/contigs_500bp_high_coverage.fasta",
@@ -41,7 +41,7 @@ rule annotate_with_bakta:
         """
 
 rule get_plasmids_platon:
-    singularity:
+    container:
         singularity_envs["platon"]
     input:
         contigs = "samples/{sample}/assembly/spades/coverage_filtered/bwa/contigs_500bp_high_coverage.fasta",
@@ -57,7 +57,7 @@ rule get_plasmids_platon:
         """
 
 rule annotate_with_bakta_unfiltered_assembly:
-    singularity:
+    container:
         singularity_envs["bakta"]
     input:
         contigs = "samples/{sample}/assembly/spades_no_correction/contigs.fasta",
@@ -81,7 +81,7 @@ rule annotate_with_bakta_unfiltered_assembly:
 rule create_blast_database_from_protein_sequences:
     conda:
         "../../envs/blast.yml"
-    singularity:
+    container:
         singularity_envs["blast"]
     input:
         proteins = "samples/{sample}/annotation/{sample}.faa",
@@ -95,7 +95,7 @@ rule create_blast_database_from_protein_sequences:
 rule create_blast_database_from_contig_sequences:
     conda:
         "../../envs/blast.yml"
-    singularity:
+    container:
         singularity_envs["blast"]
     input:
         contigs = "samples/{sample}/annotation/{sample}.fna",
@@ -109,7 +109,7 @@ rule create_blast_database_from_contig_sequences:
 rule remove_fasta_part_from_gff:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         "samples/{sample}/annotation/{sample}.gff3"
@@ -121,7 +121,7 @@ rule remove_fasta_part_from_gff:
 rule get_CDS_and_contigs_depth:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         "samples/{sample}/assembly/spades/contigs_500bp_renamed.fasta",

--- a/rules/annotation/resistance/custom_annotated_dbs.rules
+++ b/rules/annotation/resistance/custom_annotated_dbs.rules
@@ -1,7 +1,7 @@
 rule keep_only_annotated_region:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]
     input:
         genotype = "samples/{sample}/snps/gatk/" + reference_assembly_for_resistance[species] + "/{bwa_or_stringent}/snps.g.vcf.gz",
@@ -17,7 +17,7 @@ rule keep_only_annotated_region:
 rule decompose_multiallelic_positions_from_genotyping:
     conda:
         "../../envs/vt.yml"
-    singularity:
+    container:
         singularity_envs["vt"]
     input:
         genotype = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/snps_region_filtered.g.vcf.gz",
@@ -35,7 +35,7 @@ rule decompose_multiallelic_positions_from_genotyping:
 rule annotate_positions_from_genotyping:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]
     input:
         bed_gz_correct = "resistance_db/" + species + "/mutations/{db}/correct.bed.gz",
@@ -58,7 +58,7 @@ rule annotate_positions_from_genotyping:
 rule extract_mutated_codons_or_nucleotides:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]
     input:
         annotation = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/annotation.vcf",
@@ -77,7 +77,7 @@ rule extract_mutated_codons_or_nucleotides:
 rule convert_mutated_codons_or_nucleotides_to_aa_or_nucleotides:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         genotype = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/position_genotypes.txt",
@@ -90,7 +90,7 @@ rule convert_mutated_codons_or_nucleotides_to_aa_or_nucleotides:
 rule add_mutated_amino_acid_or_nucleotide_value_to_annotation_and_exclude_synonymous_mutations:
     conda:
         "../../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]
     input:
         mutation_gz = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/mutations.bed.gz",

--- a/rules/annotation/resistance/custom_annotated_dbs.rules
+++ b/rules/annotation/resistance/custom_annotated_dbs.rules
@@ -2,7 +2,7 @@ rule keep_only_annotated_region:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]
+        containers["bcftools"]
     input:
         genotype = "samples/{sample}/snps/gatk/" + reference_assembly_for_resistance[species] + "/{bwa_or_stringent}/snps.g.vcf.gz",
         genotype_tbi = "samples/{sample}/snps/gatk/" + reference_assembly_for_resistance[species] + "/{bwa_or_stringent}/snps.g.vcf.gz.tbi",
@@ -18,7 +18,7 @@ rule decompose_multiallelic_positions_from_genotyping:
     conda:
         "../../envs/vt.yml"
     container:
-        singularity_envs["vt"]
+        containers["vt"]
     input:
         genotype = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/snps_region_filtered.g.vcf.gz",
         genotype_tbi = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/snps_region_filtered.g.vcf.gz.tbi",
@@ -36,7 +36,7 @@ rule annotate_positions_from_genotyping:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]
+        containers["bcftools"]
     input:
         bed_gz_correct = "resistance_db/" + species + "/mutations/{db}/correct.bed.gz",
         bed_tbi_correct = "resistance_db/" + species + "/mutations/{db}/correct.bed.gz.tbi",
@@ -59,7 +59,7 @@ rule extract_mutated_codons_or_nucleotides:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]
+        containers["bcftools"]
     input:
         annotation = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/annotation.vcf",
     output:
@@ -78,7 +78,7 @@ rule convert_mutated_codons_or_nucleotides_to_aa_or_nucleotides:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         genotype = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/position_genotypes.txt",
     output:
@@ -91,7 +91,7 @@ rule add_mutated_amino_acid_or_nucleotide_value_to_annotation_and_exclude_synony
     conda:
         "../../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]
+        containers["bcftools"]
     input:
         mutation_gz = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/mutations.bed.gz",
         mutation_tbi = "samples/{sample}/resistance/{bwa_or_stringent}/{db}/mutations.bed.gz.tbi",

--- a/rules/annotation/resistance/customdb.rules
+++ b/rules/annotation/resistance/customdb.rules
@@ -3,7 +3,7 @@ if "BLDB_path" in config:
 
     rule search_resistance_with_ssearch:
         container:
-            singularity_envs["fasta36"]
+            containers["fasta36"]
         threads:
             8
         input:
@@ -19,7 +19,7 @@ if "BLDB_path" in config:
 
     rule resistance_filter_BBH:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         threads:
             1
         params:
@@ -37,7 +37,7 @@ if "BLDB_path" in config:
 
 rule resistance_combined_table:
     container:
-        singularity_envs["python_r"]   
+        containers["python_r"]   
     input:
         res_files=expand("samples/{{sample}}/resistance/{tool}_{{sample}}.tsv", tool=config["resistance"]),
     output:

--- a/rules/annotation/resistance/customdb.rules
+++ b/rules/annotation/resistance/customdb.rules
@@ -2,7 +2,7 @@
 if "BLDB_path" in config:
 
     rule search_resistance_with_ssearch:
-        singularity:
+        container:
             singularity_envs["fasta36"]
         threads:
             8
@@ -18,7 +18,7 @@ if "BLDB_path" in config:
             """
 
     rule resistance_filter_BBH:
-        singularity:
+        container:
             singularity_envs["python_r"]
         threads:
             1
@@ -36,7 +36,7 @@ if "BLDB_path" in config:
         script: "scripts/extract_BBH.py"
 
 rule resistance_combined_table:
-    singularity:
+    container:
         singularity_envs["python_r"]   
     input:
         res_files=expand("samples/{{sample}}/resistance/{tool}_{{sample}}.tsv", tool=config["resistance"]),

--- a/rules/annotation/resistance/detect_insertions_or_deletions.rules
+++ b/rules/annotation/resistance/detect_insertions_or_deletions.rules
@@ -2,7 +2,7 @@ rule extract_coverage_from_bed:
     conda:
         "../../../envs/bedtools.yml"
     container:
-        singularity_envs["bedtools"]
+        containers["bedtools"]
     input:
         mapping = "samples/{sample}/mapping/bwa/{ref}_deduplicated_filtered.bam",
         bed = "resistance/annotations/{gene}.bed"
@@ -17,7 +17,7 @@ rule create_bed_from_gene:
     conda:
         "../../../envs/python-r.yml"
     container:
-       singularity_envs["python_r"]
+       containers["python_r"]
     params:
         up_down = upstream_downstream
     input:
@@ -33,7 +33,7 @@ rule plot_coverage_over_gene_and_flanking:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     params:
         up_down = upstream_downstream 
     input:
@@ -50,7 +50,7 @@ rule extract_insert_size_over_gene_and_flanking:
     conda:
         "../../envs/samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]
+        containers["bwa_samtools"]
     input:
         mapping = "samples/{sample}/mapping/bwa/{ref}_deduplicated_filtered.bam",
         bed = "resistance/annotations/{gene}.bed",
@@ -67,7 +67,7 @@ rule plot_insert_size_over_gene_and_flanking:
     conda:
         "../../envs/python-r.yml"
     container:
-       singularity_envs["python_r"]
+       containers["python_r"]
     params:
         up_down = upstream_downstream 
     input:

--- a/rules/annotation/resistance/detect_insertions_or_deletions.rules
+++ b/rules/annotation/resistance/detect_insertions_or_deletions.rules
@@ -1,7 +1,7 @@
 rule extract_coverage_from_bed:
     conda:
         "../../../envs/bedtools.yml"
-    singularity:
+    container:
         singularity_envs["bedtools"]
     input:
         mapping = "samples/{sample}/mapping/bwa/{ref}_deduplicated_filtered.bam",
@@ -16,7 +16,7 @@ rule extract_coverage_from_bed:
 rule create_bed_from_gene:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
        singularity_envs["python_r"]
     params:
         up_down = upstream_downstream
@@ -32,7 +32,7 @@ rule create_bed_from_gene:
 rule plot_coverage_over_gene_and_flanking:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     params:
         up_down = upstream_downstream 
@@ -49,7 +49,7 @@ rule extract_insert_size_over_gene_and_flanking:
         up_down = upstream_downstream
     conda:
         "../../envs/samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]
     input:
         mapping = "samples/{sample}/mapping/bwa/{ref}_deduplicated_filtered.bam",
@@ -66,7 +66,7 @@ rule extract_insert_size_over_gene_and_flanking:
 rule plot_insert_size_over_gene_and_flanking:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
        singularity_envs["python_r"]
     params:
         up_down = upstream_downstream 

--- a/rules/annotation/resistance/format_xlsx.rules
+++ b/rules/annotation/resistance/format_xlsx.rules
@@ -2,7 +2,7 @@ rule convert_tsv_to_xlsx:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         tsv = "samples/{sample}/resistance/{software}_{sample}.tsv",
     output:
@@ -15,7 +15,7 @@ rule convert_csv_to_xlsx:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         tsv = "samples/{sample}/resistance/{software}_{sample}.csv",
     output:
@@ -29,7 +29,7 @@ rule merge_rgi_or_mykrobe_xlsx:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         xlsx = expand("samples/{sample}/resistance/{{software}}_{sample}.xlsx", sample=read_naming.keys())
     output:
@@ -41,7 +41,7 @@ rule merge_rgi_ontology_xlsx:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         xlsx = expand("samples/{sample}/resistance/rgi_ontology.xlsx", sample=read_naming.keys())
     output:

--- a/rules/annotation/resistance/format_xlsx.rules
+++ b/rules/annotation/resistance/format_xlsx.rules
@@ -1,7 +1,7 @@
 rule convert_tsv_to_xlsx:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         tsv = "samples/{sample}/resistance/{software}_{sample}.tsv",
@@ -14,7 +14,7 @@ rule convert_tsv_to_xlsx:
 rule convert_csv_to_xlsx:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         tsv = "samples/{sample}/resistance/{software}_{sample}.csv",
@@ -28,7 +28,7 @@ rule convert_csv_to_xlsx:
 rule merge_rgi_or_mykrobe_xlsx:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         xlsx = expand("samples/{sample}/resistance/{{software}}_{sample}.xlsx", sample=read_naming.keys())
@@ -40,7 +40,7 @@ rule merge_rgi_or_mykrobe_xlsx:
 rule merge_rgi_ontology_xlsx:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         xlsx = expand("samples/{sample}/resistance/rgi_ontology.xlsx", sample=read_naming.keys())

--- a/rules/annotation/resistance/mykrobe.rules
+++ b/rules/annotation/resistance/mykrobe.rules
@@ -10,7 +10,7 @@ def check_if_paired(wildcards):
 rule search_resistance_paired_reads_with_mykrobe:
     conda:
         "../../../envs/mykrobe.yml"
-    singularity:
+    container:
         singularity_envs["mykrobe"]
     params:
         panel = mykrobe_panel,
@@ -45,7 +45,7 @@ rule search_resistance_paired_reads_with_mykrobe:
 rule search_resistance_single_reads_with_mykrobe:
     conda:
         "../../../envs/mykrobe.yml"
-    singularity:
+    container:
         "docker:quay.io/biocontainers/mykrobe:0.7.0--py37h2666aa9_0"
     params:
         panel = mykrobe_panel,
@@ -75,7 +75,7 @@ rule search_resistance_single_reads_with_mykrobe:
 
 
 rule generate_mykrobe_tsv_file_from_json_file:
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         "samples/{sample}/resistance/mykrobe_{sample}.json",

--- a/rules/annotation/resistance/mykrobe.rules
+++ b/rules/annotation/resistance/mykrobe.rules
@@ -11,7 +11,7 @@ rule search_resistance_paired_reads_with_mykrobe:
     conda:
         "../../../envs/mykrobe.yml"
     container:
-        singularity_envs["mykrobe"]
+        containers["mykrobe"]
     params:
         panel = mykrobe_panel,
         species = mykrobe_species[species.split("_")[0]],
@@ -76,7 +76,7 @@ rule search_resistance_single_reads_with_mykrobe:
 
 rule generate_mykrobe_tsv_file_from_json_file:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         "samples/{sample}/resistance/mykrobe_{sample}.json",
     output:

--- a/rules/annotation/resistance/rgi.rules
+++ b/rules/annotation/resistance/rgi.rules
@@ -1,23 +1,4 @@
 
-'''
-rule search_resistance_with_rgi_contigs:
-    conda:
-        "../../../envs/rgi.yml"
-    container:
-        containers["rgi"]
-    threads:
-        4
-    input:
-        "samples/{sample}/annotation/{sample}.fna"
-    output:
-        "samples/{sample}/resistance/rgi_{sample}.json"
-    shell:
-        """
-        # new version
-        rgi main -t contig -i {input[0]} -n {threads} -o $(dirname {output[0]})/rgi_{wildcards.sample}
-        """
-'''
-
 rule search_resistance_with_rgi_faa:
     conda:
         "../../../envs/rgi.yml"
@@ -31,7 +12,6 @@ rule search_resistance_with_rgi_faa:
         "samples/{sample}/resistance/rgi_{sample}.json"
     shell:
         """
-        # new version
         rgi main -t protein -i {input[0]} -n {threads} -o $(dirname {output[0]})/rgi_{wildcards.sample}
         """
 

--- a/rules/annotation/resistance/rgi.rules
+++ b/rules/annotation/resistance/rgi.rules
@@ -3,7 +3,7 @@
 rule search_resistance_with_rgi_contigs:
     conda:
         "../../../envs/rgi.yml"
-    singularity:
+    container:
         singularity_envs["rgi"]
     threads:
         4
@@ -21,7 +21,7 @@ rule search_resistance_with_rgi_contigs:
 rule search_resistance_with_rgi_faa:
     conda:
         "../../../envs/rgi.yml"
-    singularity:
+    container:
         singularity_envs["rgi"]
     threads:
         4
@@ -38,7 +38,7 @@ rule search_resistance_with_rgi_faa:
 rule generate_rgi_tsv_file_from_json_file:
     conda:
         "../../../envs/rgi.yml"
-    singularity:
+    container:
         singularity_envs["rgi"]
     input:
         "samples/{sample}/resistance/rgi_{sample}.json"
@@ -55,7 +55,7 @@ rule format_rgi_tsv:
     '''
     add start, stop nucleotide sequence to table
     '''
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         gbk = "samples/{sample}/annotation/{sample}.gbff",
@@ -73,7 +73,7 @@ rule format_rgi_tsv:
 rule plot_rgi:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         rgi_files=expand("samples/{sample}/resistance/combined_{sample}.tsv", sample=read_naming.keys()),
@@ -89,7 +89,7 @@ rule plot_rgi:
 rule generate_rgi_BLDB_html_report:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         combined_tsv_output="samples/{sample}/resistance/combined_{sample}.tsv",

--- a/rules/annotation/resistance/rgi.rules
+++ b/rules/annotation/resistance/rgi.rules
@@ -4,7 +4,7 @@ rule search_resistance_with_rgi_contigs:
     conda:
         "../../../envs/rgi.yml"
     container:
-        singularity_envs["rgi"]
+        containers["rgi"]
     threads:
         4
     input:
@@ -22,7 +22,7 @@ rule search_resistance_with_rgi_faa:
     conda:
         "../../../envs/rgi.yml"
     container:
-        singularity_envs["rgi"]
+        containers["rgi"]
     threads:
         4
     input:
@@ -39,7 +39,7 @@ rule generate_rgi_tsv_file_from_json_file:
     conda:
         "../../../envs/rgi.yml"
     container:
-        singularity_envs["rgi"]
+        containers["rgi"]
     input:
         "samples/{sample}/resistance/rgi_{sample}.json"
     output:
@@ -56,7 +56,7 @@ rule format_rgi_tsv:
     add start, stop nucleotide sequence to table
     '''
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         gbk = "samples/{sample}/annotation/{sample}.gbff",
         rgi_out = "samples/{sample}/resistance/rgi_{sample}_raw.tsv",
@@ -74,7 +74,7 @@ rule plot_rgi:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         rgi_files=expand("samples/{sample}/resistance/combined_{sample}.tsv", sample=read_naming.keys()),
     params:
@@ -90,7 +90,7 @@ rule generate_rgi_BLDB_html_report:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         combined_tsv_output="samples/{sample}/resistance/combined_{sample}.tsv",
         contig_gc_depth_file="samples/{sample}/quality/mapping/bwa/{sample}_assembled_genome/contig_gc_depth_500bp_high_coverage.tab",

--- a/rules/annotation/resistance/scripts/plot_gene_presence_heatmap.R
+++ b/rules/annotation/resistance/scripts/plot_gene_presence_heatmap.R
@@ -4,27 +4,43 @@ library(grid)
 library(egg)
 library(svglite)
 
+
 rgi_files <- snakemake@input[["rgi_files"]]
 species <- snakemake@params[["species"]]
-sample_table <- data.frame(file=rgi_files, species=species, stringsAsFactors=FALSE)
+sample_table <- data.frame(
+  file = rgi_files, species = species,
+  stringsAsFactors = FALSE
+)
 
-for (i in 1:nrow(sample_table)){
-  rgi_results_file <- sample_table[i,1]
-  mechanism_file <-sample_table[i,3]
-  species <- sample_table[i,2]
+for (i in 1:nrow(sample_table)) {
+  rgi_results_file <- sample_table[i, 1]
+  mechanism_file <- sample_table[i, 3]
+  species <- sample_table[i, 2]
 
   # if the merged dataset doesn't exist, create it
-  if (!exists("dataset")){
-    dataset <- read.csv(rgi_results_file, header=TRUE, sep="\t",stringsAsFactors=FALSE)
-    dataset$sample <- rep(unlist(strsplit(rgi_results_file, "/"))[2], length(dataset[,1]))
-    dataset$species <- rep(species, length(dataset[,1]))
+  if (!exists("dataset")) {
+    dataset <- read.csv(rgi_results_file,
+      header = TRUE,
+      sep = "\t", stringsAsFactors = FALSE
+    )
+    dataset$sample <- rep(
+      unlist(strsplit(rgi_results_file, "/"))[2],
+      length(dataset[, 1])
+    )
+    dataset$species <- rep(species, length(dataset[, 1]))
   }
   # if the merged dataset does exist, append to it
-  if (exists("dataset")){
-    temp_dataset <-read.csv(rgi_results_file, header=TRUE, sep="\t",stringsAsFactors=FALSE)
-    temp_dataset$sample <- rep(unlist(strsplit(rgi_results_file, "/"))[2], length(temp_dataset[,1]))
-    temp_dataset$species <- rep(species, length(temp_dataset[,1]))
-    dataset<-rbind(dataset, temp_dataset)
+  if (exists("dataset")) {
+    temp_dataset <- read.csv(rgi_results_file,
+      header = TRUE,
+      sep = "\t", stringsAsFactors = FALSE
+    )
+    temp_dataset$sample <- rep(
+      unlist(strsplit(rgi_results_file, "/"))[2],
+      length(temp_dataset[, 1])
+    )
+    temp_dataset$species <- rep(species, length(temp_dataset[, 1]))
+    dataset <- rbind(dataset, temp_dataset)
     rm(temp_dataset)
   }
 }
@@ -32,64 +48,77 @@ for (i in 1:nrow(sample_table)){
 # sort factors
 u <- unique(dataset$Best_hit)
 u_sort <- u[rev(order(u))]
-dataset$Best_hit <- factor(dataset$Best_hit, levels=u_sort)
+dataset$Best_hit <- factor(dataset$Best_hit, levels = u_sort)
 
 # overview plot
 # prepare one plot/resistance mechanism
 plot_list <- list()
-for (i in 1:length(unique(dataset$Mechanism))){
-    resistance_mechanism <- unique(dataset$Mechanism)[i]
-    mechanism_subset <- dataset[dataset$Mechanism==resistance_mechanism,]
-    p <- ggplot(data = mechanism_subset, aes(x = sample, y = Best_hit)) + geom_tile(aes(fill = Cut_Off), height = 0.9, width=0.9)
-    p <- p + theme_grey(base_size = 10)  + theme(axis.text.x = element_text(angle = 90, hjust = 1))
-    p <- p + coord_fixed(ratio=1) + theme(legend.position="none") + ggtitle(resistance_mechanism) #+ theme(strip.text.x = element_text(size=8, angle=75))
-    p <- p + theme(axis.title.x=element_blank())
-    p <- p + theme(axis.title.y=element_blank())
-    plot_list[[i]] <- p
+for (i in 1:length(unique(dataset$Mechanism))) {
+  resistance_mechanism <- unique(dataset$Mechanism)[i]
+  mechanism_subset <- dataset[dataset$Mechanism == resistance_mechanism, ]
+  p <- ggplot(data = mechanism_subset, aes(x = sample, y = Best_hit)) +
+    geom_tile(aes(fill = Cut_Off), height = 0.9, width = 0.9)
+  p <- p + theme_grey(base_size = 10) +
+    theme(axis.text.x = element_text(angle = 90, hjust = 1))
+  p <- p + coord_fixed(ratio = 1) +
+    theme(legend.position = "none") +
+    ggtitle(resistance_mechanism)
+  p <- p + theme(axis.title.x = element_blank())
+  p <- p + theme(axis.title.y = element_blank())
+  plot_list[[i]] <- p
 }
 # with of the plot should take into accounts:
 # 1) the number of trains
 # 2) the length of labels
 label_length <- lapply(as.character(dataset$Best_hit), nchar)
 longest_label <- max(unlist(label_length))
-svglite(snakemake@output[["rgi_plot"]], height=25,width=longest_label/15 + (0.5*length(rgi_files)))
-#p <- ggplot(data = dataset, aes(x = sample, y = Best_hit)) + geom_raster(aes(fill = CUT_OFF))
-#p <- p + theme_grey(base_size = 10)  + theme(axis.text.x = element_text(angle = 90, hjust = 1))
-#print (p + coord_fixed(ratio=1))
-ggarrange(plots=plot_list, ncol = 1, newpage = FALSE)
+svglite(snakemake@output[["rgi_plot"]],
+  height = 25,
+  width = longest_label / 15 + (0.5 * length(rgi_files))
+)
+ggarrange(plots = plot_list, ncol = 1, newpage = FALSE)
 dev.off()
 
 ###
 # produce one plot per species
 nr_species <- unique(sample_table$species)
 
-for (species in nr_species){
-    sub_dataset <- dataset[dataset$species==species,]
-    # sort factors
-    sub_dataset$Best_hit <- as.character(sub_dataset$Best_hit)
-    u <- unique(sub_dataset$Best_hit)
-    u_sort <- u[rev(order(u))]
-    sub_dataset$Best_hit <- factor(sub_dataset$Best_hit, levels=u_sort)
-    # prepare one plot/resistance mechanism
-    plot_list <- list()
-    for (i in 1:length(unique(sub_dataset$Mechanism))){
-        print("Mechanism")
-        if(i == 0)
-            next
-        resistance_mechanism <- unique(sub_dataset$Mechanism)[i]
-        mechanism_subset <- sub_dataset[sub_dataset$Mechanism==resistance_mechanism,]
-        p <- ggplot(data = mechanism_subset, aes(x = sample, y = Best_hit)) + geom_tile(aes(fill = Cut_Off), height = 0.9, width=0.9)
-        p <- p + theme_grey(base_size = 10)  + theme(axis.text.x = element_text(angle = 90, hjust = 1))
-        p <- p + coord_fixed(ratio=1) + theme(legend.position="none") + ggtitle(resistance_mechanism) #+ theme(strip.text.x = element_text(size=8, angle=75))
-        p <- p +   theme(axis.title.x=element_blank())
-        p <- p +   theme(axis.title.y=element_blank())
-        plot_list[[i]] <- p
+for (species in nr_species) {
+  sub_dataset <- dataset[dataset$species == species, ]
+  # sort factors
+  sub_dataset$Best_hit <- as.character(sub_dataset$Best_hit)
+  u <- unique(sub_dataset$Best_hit)
+  u_sort <- u[rev(order(u))]
+  sub_dataset$Best_hit <- factor(sub_dataset$Best_hit, levels = u_sort)
+  # prepare one plot/resistance mechanism
+  plot_list <- list()
+  for (i in 1:length(unique(sub_dataset$Mechanism))) {
+    print("Mechanism")
+    if (i == 0) {
+      next
     }
+    resistance_mechanism <- unique(sub_dataset$Mechanism)[i]
+    mechanism_subset <- sub_dataset[
+      sub_dataset$Mechanism == resistance_mechanism,
+    ]
+    p <- ggplot(data = mechanism_subset, aes(x = sample, y = Best_hit)) +
+      geom_tile(aes(fill = Cut_Off), height = 0.9, width = 0.9)
+    p <- p + theme_grey(base_size = 10) +
+      theme(axis.text.x = element_text(angle = 90, hjust = 1))
+    p <- p + coord_fixed(ratio = 1) +
+      theme(legend.position = "none") +
+      ggtitle(resistance_mechanism)
+    p <- p + theme(axis.title.x = element_blank())
+    p <- p + theme(axis.title.y = element_blank())
+    plot_list[[i]] <- p
+  }
 
-    # plot multiplot
-    w <- length(unique(sub_dataset$species))*9
-    h <- length(unique(sub_dataset$Best_hit))/2
-    svglite(paste('report/resistance/', species, '.svg', sep=''), width=w, height=h)
-        ggarrange(plots=plot_list, ncol = 1, newpage = FALSE)
-    dev.off()
+  # plot multiplot
+  w <- length(unique(sub_dataset$species)) * 9
+  h <- length(unique(sub_dataset$Best_hit)) / 2
+  svglite(paste("report/resistance/", species, ".svg", sep = ""),
+    width = w, height = h
+  )
+  ggarrange(plots = plot_list, ncol = 1, newpage = FALSE)
+  dev.off()
 }

--- a/rules/annotation/resistance/summarize_results.rules
+++ b/rules/annotation/resistance/summarize_results.rules
@@ -2,7 +2,7 @@ rule summary_csv_excel_file:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     params:
         ontology_aro = ontology_file_aro,
         ontology_mo = ontology_file_mo,
@@ -21,7 +21,7 @@ rule write_congruent_results_fasta:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         "samples/{sample}/resistance/{software}_summary.tsv",
         "samples/{sample}/resistance/{software}_rgi.tsv",
@@ -36,7 +36,7 @@ rule merge_summary_xlsx_files:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         xlsx=expand("samples/{sample}/resistance/{software}_summary.xlsx", sample = read_naming.keys()),
 #        fastas=expand("samples/{sample}/resistance/sequences.faa", sample = read_naming.keys()),

--- a/rules/annotation/resistance/summarize_results.rules
+++ b/rules/annotation/resistance/summarize_results.rules
@@ -1,7 +1,7 @@
 rule summary_csv_excel_file:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     params:
         ontology_aro = ontology_file_aro,
@@ -20,7 +20,7 @@ rule summary_csv_excel_file:
 rule write_congruent_results_fasta:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         "samples/{sample}/resistance/{software}_summary.tsv",
@@ -35,7 +35,7 @@ rule write_congruent_results_fasta:
 rule merge_summary_xlsx_files:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         xlsx=expand("samples/{sample}/resistance/{software}_summary.xlsx", sample = read_naming.keys()),

--- a/rules/annotation/resistance/tb-profiler.rules
+++ b/rules/annotation/resistance/tb-profiler.rules
@@ -4,7 +4,7 @@ rule search_resistance_with_tbprofiler:
     conda:
         "../../../envs/rgi.yml"
     container:
-        singularity_envs["tb-profiler"]
+        containers["tb-profiler"]
     threads:
         4
     input:

--- a/rules/annotation/resistance/tb-profiler.rules
+++ b/rules/annotation/resistance/tb-profiler.rules
@@ -3,7 +3,7 @@
 rule search_resistance_with_tbprofiler:
     conda:
         "../../../envs/rgi.yml"
-    singularity:
+    container:
         singularity_envs["tb-profiler"]
     threads:
         4

--- a/rules/annotation/scripts/calculate_CDS_depth.py
+++ b/rules/annotation/scripts/calculate_CDS_depth.py
@@ -1,5 +1,8 @@
 
 import numpy
+import pandas
+from Bio import SeqIO
+from Bio.SeqUtils import gc_fraction
 
 fna_file = snakemake.input[0]
 gbk_file = snakemake.input[1]
@@ -40,7 +43,7 @@ def get_contig_id2mean_depth(contig2depth_list):
 
 def contig_id2contig_length(contigs_file):
 
-    from Bio import SeqIO
+    
 
     fasta_handle = open(contigs_file, 'r')
     id2length = {}
@@ -52,21 +55,20 @@ def contig_id2contig_length(contigs_file):
 
 def contig_id2gc_content(contigs_file):
 
-    from Bio import SeqIO
-    from Bio.SeqUtils import GC
+
+    
 
     fasta_handle = open(contigs_file, 'r')
     id2gc = {}
     cumul_seq = ''
     for record in SeqIO.parse(fasta_handle, "fasta"):
-        id2gc[record.name] = GC(record.seq)
+        id2gc[record.name] = gc_fraction(record.seq)
         cumul_seq += record.seq
-    id2gc["TOTAL"] = round(GC(cumul_seq), 2)
+    id2gc["TOTAL"] = round(gc_fraction(cumul_seq), 2)
     return id2gc
 
 def gbk2CDS_loc(gbk_file):
 
-    from Bio import SeqIO
     record2locus2location = {}
     with open(gbk_file, 'r') as f:
         for record in SeqIO.parse(f, 'genbank'):
@@ -79,7 +81,7 @@ def gbk2CDS_loc(gbk_file):
     return record2locus2location
 
 def parse_smatools_depth(samtools_depth):
-    import pandas
+
 
     with open(samtools_depth, 'r') as f:
         table = pandas.read_csv(f, sep='\t', header=None, index_col=0)

--- a/rules/annotation/virulence.rules
+++ b/rules/annotation/virulence.rules
@@ -1,7 +1,7 @@
 rule blast_virulence_protein_to_proteome_or_contigs:
     conda:
         "../../envs/blast.yml"
-    singularity:
+    container:
         singularity_envs["blast"]
     params:
         perc_id_cutoff=config["virulence_percentage_identity_cutoff"],
@@ -40,7 +40,7 @@ rule blast_virulence_protein_to_proteome_or_contigs:
 rule remove_redundancy_from_blast_results:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         "samples/{sample}/virulence/results_blast.tsv",
@@ -53,7 +53,7 @@ rule remove_redundancy_from_blast_results:
 rule extract_protein_sequences_from_blast_results:
     conda:
         "../../envs/samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]
     input:
         blast_res = "samples/{sample}/virulence/results_blast_not_redundant.tsv",
@@ -77,7 +77,7 @@ if "virulence_factors" in config:
     rule add_description_to_blast_results:
         conda:
             "../../envs/python-r.yml"
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             "samples/{sample}/virulence/results_blast_not_redundant.tsv",
@@ -92,7 +92,7 @@ if "virulence_factors" in config:
 rule merge_samples_summary:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         xlsx=expand("samples/{sample}/virulence/{sample}_virulence_summary.xlsx", sample = read_naming.keys()),
@@ -105,7 +105,7 @@ rule merge_samples_summary:
 rule generate_html_report:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         blast_results="samples/{sample}/virulence/{sample}_virulence_summary.xlsx",
@@ -119,7 +119,7 @@ rule generate_html_report:
 rule blast_proteome_to_VFDB:
     conda:
         "../../envs/blast.yml"
-    singularity:
+    container:
         singularity_envs["blast"]
     params:
         perc_id_cutoff=config["virulence_percentage_identity_cutoff"],
@@ -139,7 +139,7 @@ rule blast_proteome_to_VFDB:
 rule generate_VFDB_report:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         blast_results="samples/{sample}/virulence/VFDB_results_blast.tsv",
@@ -155,7 +155,7 @@ rule generate_VFDB_report:
 rule merge_virulence_files:
     conda:
         "../../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
          tsv=expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),
@@ -170,7 +170,7 @@ rule merge_virulence_files:
 rule prepare_label_file_for_circos:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         gbk_file="samples/{sample}/annotation/{sample}.gbff",

--- a/rules/annotation/virulence.rules
+++ b/rules/annotation/virulence.rules
@@ -2,7 +2,7 @@ rule blast_virulence_protein_to_proteome_or_contigs:
     conda:
         "../../envs/blast.yml"
     container:
-        singularity_envs["blast"]
+        containers["blast"]
     params:
         perc_id_cutoff=config["virulence_percentage_identity_cutoff"],
         cov_cutoff=config["virulence_coverage_cutoff"],
@@ -41,7 +41,7 @@ rule remove_redundancy_from_blast_results:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         "samples/{sample}/virulence/results_blast.tsv",
     output:
@@ -54,7 +54,7 @@ rule extract_protein_sequences_from_blast_results:
     conda:
         "../../envs/samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]
+        containers["bwa_samtools"]
     input:
         blast_res = "samples/{sample}/virulence/results_blast_not_redundant.tsv",
         annotation_prot = "samples/{sample}/annotation/{sample}.faa",
@@ -78,7 +78,7 @@ if "virulence_factors" in config:
         conda:
             "../../envs/python-r.yml"
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             "samples/{sample}/virulence/results_blast_not_redundant.tsv",
             config["virulence_factors"]
@@ -93,7 +93,7 @@ rule merge_samples_summary:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         xlsx=expand("samples/{sample}/virulence/{sample}_virulence_summary.xlsx", sample = read_naming.keys()),
         fasta=expand("samples/{sample}/virulence/proteins.fasta", sample = read_naming.keys()),
@@ -106,7 +106,7 @@ rule generate_html_report:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         blast_results="samples/{sample}/virulence/{sample}_virulence_summary.xlsx",
     params:
@@ -120,7 +120,7 @@ rule blast_proteome_to_VFDB:
     conda:
         "../../envs/blast.yml"
     container:
-        singularity_envs["blast"]
+        containers["blast"]
     params:
         perc_id_cutoff=config["virulence_percentage_identity_cutoff"],
         cov_cutoff=config["virulence_coverage_cutoff"],
@@ -140,7 +140,7 @@ rule generate_VFDB_report:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         blast_results="samples/{sample}/virulence/VFDB_results_blast.tsv",
         VFDB_annotation="references/virulence/VFDB_annotations.tab",
@@ -156,7 +156,7 @@ rule merge_virulence_files:
     conda:
         "../../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
          tsv=expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),
     output:
@@ -171,7 +171,7 @@ rule prepare_label_file_for_circos:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         gbk_file="samples/{sample}/annotation/{sample}.gbff",
         blast_results="samples/{sample}/virulence/VFDB_results_blast.tsv",

--- a/rules/assembly/spades.rules
+++ b/rules/assembly/spades.rules
@@ -12,7 +12,7 @@ rule correct_error_paired_reads_with_spades:
     conda:
         "../../envs/spades.yml"
     container:
-       singularity_envs["spades"]
+       containers["spades"]
     threads:
         4
     input:
@@ -33,7 +33,7 @@ rule correct_error_single_reads_with_spades:
     conda:
         "../../envs/spades.yml"
     container:
-        singularity_envs["spades"]
+        containers["spades"]
     threads:
         4
     input:
@@ -54,7 +54,7 @@ rule assemble_genome_corrected_paired_reads_with_spades:
     conda:
         "../../envs/spades.yml"
     container:
-        singularity_envs["spades"]
+        containers["spades"]
     threads:
         4
     input:
@@ -82,7 +82,7 @@ rule assemble_genome_corrected_single_reads_with_spades:
     conda:
         "../../envs/spades.yml"
     container:
-        singularity_envs["spades"]
+        containers["spades"]
     threads:
         4
     input:
@@ -107,7 +107,7 @@ rule assemble_genome_paired_reads_with_spades:
     conda:
         "../../envs/spades.yml"
     container:
-        singularity_envs["spades"]
+        containers["spades"]
     threads:
         4
     input:
@@ -131,7 +131,7 @@ rule assemble_genome_single_reads_with_spades:
     conda:
         "../../envs/spades.yml"
     container:
-        singularity_envs["spades"]
+        containers["spades"]
     threads:
         4
     input:

--- a/rules/assembly/spades.rules
+++ b/rules/assembly/spades.rules
@@ -11,7 +11,7 @@ def check_if_paired(wildcards):
 rule correct_error_paired_reads_with_spades:
     conda:
         "../../envs/spades.yml"
-    singularity:
+    container:
        singularity_envs["spades"]
     threads:
         4
@@ -32,7 +32,7 @@ rule correct_error_paired_reads_with_spades:
 rule correct_error_single_reads_with_spades:
     conda:
         "../../envs/spades.yml"
-    singularity:
+    container:
         singularity_envs["spades"]
     threads:
         4
@@ -53,7 +53,7 @@ ruleorder: assemble_genome_corrected_paired_reads_with_spades > assemble_genome_
 rule assemble_genome_corrected_paired_reads_with_spades:
     conda:
         "../../envs/spades.yml"
-    singularity:
+    container:
         singularity_envs["spades"]
     threads:
         4
@@ -81,7 +81,7 @@ rule assemble_genome_corrected_paired_reads_with_spades:
 rule assemble_genome_corrected_single_reads_with_spades:
     conda:
         "../../envs/spades.yml"
-    singularity:
+    container:
         singularity_envs["spades"]
     threads:
         4
@@ -106,7 +106,7 @@ rule assemble_genome_corrected_single_reads_with_spades:
 rule assemble_genome_paired_reads_with_spades:
     conda:
         "../../envs/spades.yml"
-    singularity:
+    container:
         singularity_envs["spades"]
     threads:
         4
@@ -130,7 +130,7 @@ rule assemble_genome_paired_reads_with_spades:
 rule assemble_genome_single_reads_with_spades:
     conda:
         "../../envs/spades.yml"
-    singularity:
+    container:
         singularity_envs["spades"]
     threads:
         4

--- a/rules/benchmark/resistance/compare_results.rules
+++ b/rules/benchmark/resistance/compare_results.rules
@@ -4,7 +4,7 @@ if 'sra_samples' in config:
 
     rule compare_MTB_res_search:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             table_2 = "{path}_benchmark.tsv"
         params:
@@ -21,7 +21,7 @@ if 'sra_samples' in config:
 
     rule add_reference_phenotype:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             table_2 = "{path}_frequency.tsv"
         params:
@@ -34,7 +34,7 @@ if 'sra_samples' in config:
 
     rule statistics_wrong_results:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             rgi = "report/resistance/rgi_variant_phenotype.tsv",
             mykrobe = "report/resistance/mykrobe_variant_phenotype.tsv",

--- a/rules/benchmark/resistance/compare_results.rules
+++ b/rules/benchmark/resistance/compare_results.rules
@@ -3,7 +3,7 @@
 if 'sra_samples' in config:
 
     rule compare_MTB_res_search:
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             table_2 = "{path}_benchmark.tsv"
@@ -20,7 +20,7 @@ if 'sra_samples' in config:
 
 
     rule add_reference_phenotype:
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             table_2 = "{path}_frequency.tsv"
@@ -33,7 +33,7 @@ if 'sra_samples' in config:
 
 
     rule statistics_wrong_results:
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             rgi = "report/resistance/rgi_variant_phenotype.tsv",

--- a/rules/benchmark/resistance/custom_annotated_dbs.rules
+++ b/rules/benchmark/resistance/custom_annotated_dbs.rules
@@ -1,6 +1,6 @@
 
 rule combine_all_customdb_MTB:
-    singularity:
+    container:
         singularity_envs["pyvcf"]
     input:
         all_custom_db = expand("samples/{sample}/resistance/{{bwa_or_stringent}}/{{db}}/mutations.vcf", sample = read_naming.keys()),
@@ -12,7 +12,7 @@ rule combine_all_customdb_MTB:
         
 
 rule frequency_customdb_MTB:
-    singularity:
+    container:
         singularity_envs["pyvcf"]
     input:
         all_custom_db = expand("samples/{sample}/resistance/{{bwa_or_stringent}}/{{db}}/mutations.vcf", sample = read_naming.keys()),

--- a/rules/benchmark/resistance/custom_annotated_dbs.rules
+++ b/rules/benchmark/resistance/custom_annotated_dbs.rules
@@ -1,7 +1,7 @@
 
 rule combine_all_customdb_MTB:
     container:
-        singularity_envs["pyvcf"]
+        containers["pyvcf"]
     input:
         all_custom_db = expand("samples/{sample}/resistance/{{bwa_or_stringent}}/{{db}}/mutations.vcf", sample = read_naming.keys()),
         resistance_genes = "resistance_db/Mycobacterium_tuberculosis/metadata/resistance_genes.tsv"
@@ -13,7 +13,7 @@ rule combine_all_customdb_MTB:
 
 rule frequency_customdb_MTB:
     container:
-        singularity_envs["pyvcf"]
+        containers["pyvcf"]
     input:
         all_custom_db = expand("samples/{sample}/resistance/{{bwa_or_stringent}}/{{db}}/mutations.vcf", sample = read_naming.keys()),
         resistance_genes = "resistance_db/Mycobacterium_tuberculosis/metadata/resistance_genes.tsv"

--- a/rules/benchmark/resistance/mykrobe.rules
+++ b/rules/benchmark/resistance/mykrobe.rules
@@ -1,6 +1,6 @@
 
 rule combine_all_mykrobe:
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         all_mykrobe = expand("samples/{sample}/resistance/mykrobe_{sample}.csv", sample = read_naming.keys())
@@ -11,7 +11,7 @@ rule combine_all_mykrobe:
 
 
 rule mykrobe_variant_frequency:
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         all_mykrobe = expand("samples/{sample}/resistance/mykrobe_{sample}.csv", sample = read_naming.keys())

--- a/rules/benchmark/resistance/mykrobe.rules
+++ b/rules/benchmark/resistance/mykrobe.rules
@@ -1,7 +1,7 @@
 
 rule combine_all_mykrobe:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         all_mykrobe = expand("samples/{sample}/resistance/mykrobe_{sample}.csv", sample = read_naming.keys())
     output:
@@ -12,7 +12,7 @@ rule combine_all_mykrobe:
 
 rule mykrobe_variant_frequency:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         all_mykrobe = expand("samples/{sample}/resistance/mykrobe_{sample}.csv", sample = read_naming.keys())
     output:

--- a/rules/benchmark/resistance/rgi.rules
+++ b/rules/benchmark/resistance/rgi.rules
@@ -1,6 +1,6 @@
 
 rule combine_all_rgi:
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         all_rgi = expand("samples/{sample}/resistance/rgi_{sample}.tsv", sample = read_naming.keys())
@@ -11,7 +11,7 @@ rule combine_all_rgi:
 
 
 rule rgi_variant_frequency:
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         all_rgi = expand("samples/{sample}/resistance/rgi_{sample}.tsv", sample = read_naming.keys())

--- a/rules/benchmark/resistance/rgi.rules
+++ b/rules/benchmark/resistance/rgi.rules
@@ -1,7 +1,7 @@
 
 rule combine_all_rgi:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         all_rgi = expand("samples/{sample}/resistance/rgi_{sample}.tsv", sample = read_naming.keys())
     output:
@@ -12,7 +12,7 @@ rule combine_all_rgi:
 
 rule rgi_variant_frequency:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         all_rgi = expand("samples/{sample}/resistance/rgi_{sample}.tsv", sample = read_naming.keys())
     output:

--- a/rules/benchmark/resistance/tb-profiler.rules
+++ b/rules/benchmark/resistance/tb-profiler.rules
@@ -13,7 +13,7 @@ rule copy_tbprofiler_results:
 
 
 rule tbprofiler_collate:
-    singularity:
+    container:
         singularity_envs["tb-profiler"]
     threads:
         1
@@ -30,7 +30,7 @@ rule tbprofiler_collate:
 
 
 rule format_tbprofiler_collated:
-    singularity:
+    container:
         singularity_envs["python_r"]
     threads:
         1
@@ -44,7 +44,7 @@ rule format_tbprofiler_collated:
 
 
 rule tbprofiler_variant_frequency:
-    singularity:
+    container:
         singularity_envs["python_r"]
     threads:
         1

--- a/rules/benchmark/resistance/tb-profiler.rules
+++ b/rules/benchmark/resistance/tb-profiler.rules
@@ -14,7 +14,7 @@ rule copy_tbprofiler_results:
 
 rule tbprofiler_collate:
     container:
-        singularity_envs["tb-profiler"]
+        containers["tb-profiler"]
     threads:
         1
     input:
@@ -31,7 +31,7 @@ rule tbprofiler_collate:
 
 rule format_tbprofiler_collated:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     threads:
         1
     input:
@@ -45,7 +45,7 @@ rule format_tbprofiler_collated:
 
 rule tbprofiler_variant_frequency:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     threads:
         1
     input:

--- a/rules/benchmark/resistance/venn.rules
+++ b/rules/benchmark/resistance/venn.rules
@@ -5,7 +5,7 @@
 
 rule venn_wrong_results:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         rgi = "report/resistance/rgi_benchmark_{FP_or_FN}.tsv",
         mykrobe = "report/resistance/mykrobe_benchmark_{FP_or_FN}.tsv",

--- a/rules/benchmark/resistance/venn.rules
+++ b/rules/benchmark/resistance/venn.rules
@@ -4,7 +4,7 @@
 
 
 rule venn_wrong_results:
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         rgi = "report/resistance/rgi_benchmark_{FP_or_FN}.tsv",

--- a/rules/core_genome/bed_creation_parsnp.rules
+++ b/rules/core_genome/bed_creation_parsnp.rules
@@ -2,7 +2,7 @@ rule extract_core_genome_parsnp_from_ref:
     conda:
         "../../envs/bedtools.yml"
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         "core_genomes/parsnp/" + species + "/parsnp.xmfa",
         "references/{ref}/genome_fna.fna"

--- a/rules/core_genome/bed_creation_parsnp.rules
+++ b/rules/core_genome/bed_creation_parsnp.rules
@@ -1,7 +1,7 @@
 rule extract_core_genome_parsnp_from_ref:
     conda:
         "../../envs/bedtools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         "core_genomes/parsnp/" + species + "/parsnp.xmfa",

--- a/rules/core_genome/cgMLST.rules
+++ b/rules/core_genome/cgMLST.rules
@@ -1,7 +1,7 @@
 rule extract_cgMLST_regions_from_vcf:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         vcf_mutation_type = "typing/{snp_caller}/full_genome_" + str(all_core_genome_dbs.loc[species, "ReferenceGenome"]) + "/{mapping_method}/all_samples_{type}.vcf.gz",
@@ -18,7 +18,7 @@ rule extract_cgMLST_regions_from_vcf:
 rule extract_individual_cgMLST_regions_from_vcf:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         vcf = "samples/{sample}/snps/{snp_caller}/" + str(all_core_genome_dbs.loc[species, "ReferenceGenome"]) + "/{mapping_method}/freq.vcf.gz",

--- a/rules/core_genome/cgMLST.rules
+++ b/rules/core_genome/cgMLST.rules
@@ -2,7 +2,7 @@ rule extract_cgMLST_regions_from_vcf:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         vcf_mutation_type = "typing/{snp_caller}/full_genome_" + str(all_core_genome_dbs.loc[species, "ReferenceGenome"]) + "/{mapping_method}/all_samples_{type}.vcf.gz",
         vcf_mutation_type_tbi = "typing/{snp_caller}/full_genome_" + str(all_core_genome_dbs.loc[species, "ReferenceGenome"]) + "/{mapping_method}/all_samples_{type}.vcf.gz.tbi",
@@ -19,7 +19,7 @@ rule extract_individual_cgMLST_regions_from_vcf:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         vcf = "samples/{sample}/snps/{snp_caller}/" + str(all_core_genome_dbs.loc[species, "ReferenceGenome"]) + "/{mapping_method}/freq.vcf.gz",
         vcf_tbi = "samples/{sample}/snps/{snp_caller}/" + str(all_core_genome_dbs.loc[species, "ReferenceGenome"]) + "/{mapping_method}/freq.vcf.gz.tbi",

--- a/rules/downloading/adapting_genome_files.rules
+++ b/rules/downloading/adapting_genome_files.rules
@@ -21,7 +21,7 @@ rule link_full_genome:
 rule correct_gbk_extension_for_IGV_visualization:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"] 
     input:
         genome = "references/{ref}/genome_gbff.gbff",

--- a/rules/downloading/adapting_genome_files.rules
+++ b/rules/downloading/adapting_genome_files.rules
@@ -22,7 +22,7 @@ rule correct_gbk_extension_for_IGV_visualization:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"] 
+        containers["python_r"] 
     input:
         genome = "references/{ref}/genome_gbff.gbff",
     output:

--- a/rules/downloading/fetch_VFDB.rules
+++ b/rules/downloading/fetch_VFDB.rules
@@ -3,7 +3,7 @@
 rule download_VFDB_fasta:
     conda:
         "../../envs/curl.yml"
-    singularity:
+    container:
         "docker://curlimages/curl:latest"
     output:
         "references/virulence/VFDB_setA_pro.fas.gz",
@@ -13,7 +13,7 @@ rule download_VFDB_fasta:
         """
 
 rule extract_VFDB_fasta:
-    singularity:
+    container:
         "docker://kubeless/unzip:latest"
     input:
         "references/virulence/VFDB_setA_pro.fas.gz",
@@ -27,7 +27,7 @@ rule extract_VFDB_fasta:
 rule filter_VFDB_fasta_by_size:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         "docker://metagenlab/diag-pipeline-python-r:1.1"
     input:
         "references/virulence/VFDB_formated.faa",
@@ -42,7 +42,7 @@ rule filter_VFDB_fasta_by_size:
 rule format_VFDB_fasta:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         "docker://metagenlab/diag-pipeline-python-r:1.1"
     input:
         "references/virulence/VFDB_setA_pro.fas",
@@ -55,7 +55,7 @@ rule format_VFDB_fasta:
 rule create_VFDB_blast_database:
     conda:
         "../../envs/blast.yml"
-    singularity:
+    container:
         "docker://quay.io/biocontainers/blast:2.9.0--pl526h3066fca_4"
     input:
         proteins = "references/virulence/VFDB_larger_50aa.faa",

--- a/rules/downloading/fetch_mentalist_mlst_scheme.rules
+++ b/rules/downloading/fetch_mentalist_mlst_scheme.rules
@@ -1,7 +1,7 @@
 rule get_mentalist_mlst_scheme:
     conda:
         "../../envs/mentalist.yml"
-    singularity:
+    container:
         singularity_envs["mentalist"]
     params:
         species_name=lambda wildcards: str(wildcards.species).replace("_", " "),

--- a/rules/downloading/fetch_mentalist_mlst_scheme.rules
+++ b/rules/downloading/fetch_mentalist_mlst_scheme.rules
@@ -2,7 +2,7 @@ rule get_mentalist_mlst_scheme:
     conda:
         "../../envs/mentalist.yml"
     container:
-        singularity_envs["mentalist"]
+        containers["mentalist"]
     params:
         species_name=lambda wildcards: str(wildcards.species).replace("_", " "),
     output:

--- a/rules/downloading/fetch_references.rules
+++ b/rules/downloading/fetch_references.rules
@@ -4,7 +4,7 @@ rule get_refseq_urls_complete_genomes:
     conda:
         "../../envs/entrez-direct.yml"
     container:
-        singularity_envs["entrez-direct"]
+        containers["entrez-direct"]
     output:
         "references/{spec}/url_complete_genomes.txt"
     shell:
@@ -23,7 +23,7 @@ rule download_all_complete_genomes_fasta:
     conda:
         "../../envs/entrez-direct.yml"
     container:
-        singularity_envs["entrez-direct"]
+        containers["entrez-direct"]
     input:
         "references/{spec}/url_complete_genomes.txt"
     output:

--- a/rules/downloading/fetch_references.rules
+++ b/rules/downloading/fetch_references.rules
@@ -3,7 +3,7 @@ rule get_refseq_urls_complete_genomes:
         excluded_id = "" #excl_id,
     conda:
         "../../envs/entrez-direct.yml"
-    singularity:
+    container:
         singularity_envs["entrez-direct"]
     output:
         "references/{spec}/url_complete_genomes.txt"
@@ -22,7 +22,7 @@ rule get_refseq_urls_complete_genomes:
 rule download_all_complete_genomes_fasta:
     conda:
         "../../envs/entrez-direct.yml"
-    singularity:
+    container:
         singularity_envs["entrez-direct"]
     input:
         "references/{spec}/url_complete_genomes.txt"

--- a/rules/downloading/fetch_single_reference.rules
+++ b/rules/downloading/fetch_single_reference.rules
@@ -2,7 +2,7 @@ rule download_reference_from_refseq:
     conda:
         "../../envs/entrez-direct.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     output:
         genome="references/{ref,[0-9]+}/genome_{format}.{format}",
     shell:
@@ -19,7 +19,7 @@ rule download_reference_from_nucleotide:
     conda:
         "../../envs/entrez-direct.yml"
     container:
-        singularity_envs["entrez-direct"]
+        containers["entrez-direct"]
     output:
         genome="references/NC{ref}/genome_{format}.{format}",
     shell:
@@ -33,7 +33,7 @@ rule get_strain_subvalue_identifier_reference:
     conda:
         "../../envs/entrez-direct.yml"
     container:
-        singularity_envs["entrez-direct"]
+        containers["entrez-direct"]
     output:
         subvalue="references/{ref,[0-9]+}/genome_subvalue.txt",
     shell:
@@ -46,7 +46,7 @@ rule download_gff_for_reference_from_refseq:
     conda:
         "../../envs/entrez-direct.yml"
     container:
-        singularity_envs["entrez-direct"]
+        containers["entrez-direct"]
     output:
         gff="references/{ref,[0-9]+}/genome.gff"
     shell:

--- a/rules/downloading/fetch_single_reference.rules
+++ b/rules/downloading/fetch_single_reference.rules
@@ -1,7 +1,7 @@
 rule download_reference_from_refseq:
     conda:
         "../../envs/entrez-direct.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     output:
         genome="references/{ref,[0-9]+}/genome_{format}.{format}",
@@ -18,7 +18,7 @@ rule download_reference_from_refseq:
 rule download_reference_from_nucleotide:
     conda:
         "../../envs/entrez-direct.yml"
-    singularity:
+    container:
         singularity_envs["entrez-direct"]
     output:
         genome="references/NC{ref}/genome_{format}.{format}",
@@ -32,7 +32,7 @@ rule download_reference_from_nucleotide:
 rule get_strain_subvalue_identifier_reference:
     conda:
         "../../envs/entrez-direct.yml"
-    singularity:
+    container:
         singularity_envs["entrez-direct"]
     output:
         subvalue="references/{ref,[0-9]+}/genome_subvalue.txt",
@@ -45,7 +45,7 @@ rule get_strain_subvalue_identifier_reference:
 rule download_gff_for_reference_from_refseq:
     conda:
         "../../envs/entrez-direct.yml"
-    singularity:
+    container:
         singularity_envs["entrez-direct"]
     output:
         gff="references/{ref,[0-9]+}/genome.gff"

--- a/rules/genotyping/freebayes.rules
+++ b/rules/genotyping/freebayes.rules
@@ -1,7 +1,7 @@
 rule genotype_with_freebayes_on_all_samples:
     conda:
         "../../envs/freebayes.yml"
-    singularity:
+    container:
         singularity_envs["freebayes"]
     threads:
         4
@@ -24,7 +24,7 @@ rule genotype_with_freebayes_on_all_samples:
 rule genotype_with_freebayes_one_sample_second_pass:
     conda:
         "../../envs/freebayes.yml"
-    singularity:
+    container:
         singularity_envs["freebayes"]
     input:
         bam = "samples/{sample}/mapping/{mapping_method}/{ref}/deduplicated_filtered.bam",

--- a/rules/genotyping/freebayes.rules
+++ b/rules/genotyping/freebayes.rules
@@ -2,7 +2,7 @@ rule genotype_with_freebayes_on_all_samples:
     conda:
         "../../envs/freebayes.yml"
     container:
-        singularity_envs["freebayes"]
+        containers["freebayes"]
     threads:
         4
     input:
@@ -25,7 +25,7 @@ rule genotype_with_freebayes_one_sample_second_pass:
     conda:
         "../../envs/freebayes.yml"
     container:
-        singularity_envs["freebayes"]
+        containers["freebayes"]
     input:
         bam = "samples/{sample}/mapping/{mapping_method}/{ref}/deduplicated_filtered.bam",
         bai = "samples/{sample}/mapping/{mapping_method}/{ref}/deduplicated_filtered.bam.bai",

--- a/rules/genotyping/gatk.rules
+++ b/rules/genotyping/gatk.rules
@@ -3,7 +3,7 @@
 rule create_dictionary_for_reference:
     conda:
         "../../envs/gatk.yml"
-    singularity:
+    container:
         singularity_envs["gatk4"]
     input:
         ref = "references/{ref}/genome_fna.fna",
@@ -20,7 +20,7 @@ rule create_dictionary_for_reference:
 rule genotype_with_HaplotypeCaller_GATK_BP_RESOLUTION:
     conda:
         "../../envs/gatk.yml"
-    singularity:
+    container:
         singularity_envs["gatk4"]
     threads:
         2
@@ -42,7 +42,7 @@ rule genotype_with_HaplotypeCaller_GATK_BP_RESOLUTION:
 rule merge_gvcf_files_with_GenomicsDBImport_GATK:
     conda:
         "../../envs/gatk.yml"
-    singularity:
+    container:
         singularity_envs["gatk4"]
     input:
         ref = "references/{ref}/genome_fna.fna",
@@ -65,7 +65,7 @@ rule merge_gvcf_files_with_GenomicsDBImport_GATK:
 rule merge_gvcf_files_with_CombineGVCFs_GATK:
     conda:
         "../../envs/gatk.yml"
-    singularity:
+    container:
         singularity_envs["gatk4"]
     input:
         ref = "references/{ref}/genome_fna.fna",
@@ -84,7 +84,7 @@ rule merge_gvcf_files_with_CombineGVCFs_GATK:
 rule genotype_with_GenotypeGVCFs_GATK:
     conda:
         "../../envs/gatk.yml"
-    singularity:
+    container:
         singularity_envs["gatk4"]
     threads:
         4

--- a/rules/genotyping/gatk.rules
+++ b/rules/genotyping/gatk.rules
@@ -4,7 +4,7 @@ rule create_dictionary_for_reference:
     conda:
         "../../envs/gatk.yml"
     container:
-        singularity_envs["gatk4"]
+        containers["gatk4"]
     input:
         ref = "references/{ref}/genome_fna.fna",
         index = "references/{ref}/genome_fna.fna.fai"
@@ -21,7 +21,7 @@ rule genotype_with_HaplotypeCaller_GATK_BP_RESOLUTION:
     conda:
         "../../envs/gatk.yml"
     container:
-        singularity_envs["gatk4"]
+        containers["gatk4"]
     threads:
         2
     input:
@@ -43,7 +43,7 @@ rule merge_gvcf_files_with_GenomicsDBImport_GATK:
     conda:
         "../../envs/gatk.yml"
     container:
-        singularity_envs["gatk4"]
+        containers["gatk4"]
     input:
         ref = "references/{ref}/genome_fna.fna",
         gvcfs = expand("samples/{sample}/snps/gatk/{{ref}}/{{mapping_method}}/snps.g.vcf.gz", sample=read_naming.keys()),
@@ -66,7 +66,7 @@ rule merge_gvcf_files_with_CombineGVCFs_GATK:
     conda:
         "../../envs/gatk.yml"
     container:
-        singularity_envs["gatk4"]
+        containers["gatk4"]
     input:
         ref = "references/{ref}/genome_fna.fna",
         gvcfs = expand("samples/{sample}/snps/gatk/{{ref}}/{{mapping_method}}/snps.g.vcf.gz", sample=read_naming.keys()),
@@ -85,7 +85,7 @@ rule genotype_with_GenotypeGVCFs_GATK:
     conda:
         "../../envs/gatk.yml"
     container:
-        singularity_envs["gatk4"]
+        containers["gatk4"]
     threads:
         4
     input:

--- a/rules/mapping/bwa.rules
+++ b/rules/mapping/bwa.rules
@@ -13,7 +13,7 @@ def check_if_paired(wildcards):
 rule map_paired_reads_with_bwa:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]
     params:
         platform = "ILLUMINA"
@@ -38,7 +38,7 @@ rule map_paired_reads_with_bwa:
 rule map_single_reads_with_bwa:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         "docker://metagenlab/bwa-samtools:1.0"
     params:
         platform = "ILLUMINA"
@@ -64,7 +64,7 @@ rule map_single_reads_with_bwa:
 rule mapping_depth:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]  
     input:
         "samples/{sample}/mapping/bwa/{ref}.bam",
@@ -78,7 +78,7 @@ rule mapping_depth:
 rule map_paired_reads_with_bwa_for_direct_sequencing:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]
     params:
         platform = "ILLUMINA"
@@ -104,7 +104,7 @@ rule map_paired_reads_with_bwa_for_direct_sequencing:
 rule map_single_reads_with_bwa_for_direct_sequencing:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]
     params:
         platform = "ILLUMINA"
@@ -128,7 +128,7 @@ rule map_single_reads_with_bwa_for_direct_sequencing:
 rule filter_reads_on_quality:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]    
     input:
         bam = "samples/{sample}/mapping/{mapping_method}/{ref}.bam",
@@ -149,7 +149,7 @@ rule filter_reads_on_quality:
 rule remove_duplicates_from_mapping:
     conda:
         "../../envs/gatk.yml"
-    singularity:
+    container:
         singularity_envs["gatk4"]
     input:
         bam = "samples/{sample}/mapping/{mapping_method}/{ref}/filtered.bam",
@@ -167,7 +167,7 @@ rule remove_duplicates_from_mapping:
 rule extract_large_deletion_from_mapping:
     conda:
         "../../envs/bedtools.yml"
-    singularity:
+    container:
         singularity_envs["bedtools"]       
     params:
         indel_im_size = 10

--- a/rules/mapping/bwa.rules
+++ b/rules/mapping/bwa.rules
@@ -14,7 +14,7 @@ rule map_paired_reads_with_bwa:
     conda:
         "../../envs/bwa-samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]
+        containers["bwa_samtools"]
     params:
         platform = "ILLUMINA"
     input:
@@ -65,7 +65,7 @@ rule mapping_depth:
     conda:
         "../../envs/bwa-samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]  
+        containers["bwa_samtools"]  
     input:
         "samples/{sample}/mapping/bwa/{ref}.bam",
     output:
@@ -79,7 +79,7 @@ rule map_paired_reads_with_bwa_for_direct_sequencing:
     conda:
         "../../envs/bwa-samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]
+        containers["bwa_samtools"]
     params:
         platform = "ILLUMINA"
     input:
@@ -105,7 +105,7 @@ rule map_single_reads_with_bwa_for_direct_sequencing:
     conda:
         "../../envs/bwa-samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]
+        containers["bwa_samtools"]
     params:
         platform = "ILLUMINA"
     input:
@@ -129,7 +129,7 @@ rule filter_reads_on_quality:
     conda:
         "../../envs/bwa-samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]    
+        containers["bwa_samtools"]    
     input:
         bam = "samples/{sample}/mapping/{mapping_method}/{ref}.bam",
         bam_bai = "samples/{sample}/mapping/{mapping_method}/{ref}.bam.bai",
@@ -150,7 +150,7 @@ rule remove_duplicates_from_mapping:
     conda:
         "../../envs/gatk.yml"
     container:
-        singularity_envs["gatk4"]
+        containers["gatk4"]
     input:
         bam = "samples/{sample}/mapping/{mapping_method}/{ref}/filtered.bam",
         bam_bai = "samples/{sample}/mapping/{mapping_method}/{ref}/filtered.bam.bai",
@@ -168,7 +168,7 @@ rule extract_large_deletion_from_mapping:
     conda:
         "../../envs/bedtools.yml"
     container:
-        singularity_envs["bedtools"]       
+        containers["bedtools"]       
     params:
         indel_im_size = 10
     input:

--- a/rules/mapping/find_closest_genomes.rules
+++ b/rules/mapping/find_closest_genomes.rules
@@ -1,7 +1,7 @@
 rule sketch_kmers_complete_genomes_with_mash:
     conda:
         "../quality/env/mash.yml"
-    singularity:
+    container:
         singularity_envs["mash"]
     input:
         "references/all_complete_genomes_log.txt"
@@ -15,7 +15,7 @@ rule sketch_kmers_complete_genomes_with_mash:
 rule calculate_distance_to_complete_genomes_with_mash:
     conda:
         "../quality/env/mash.yml"
-    singularity:
+    container:
          singularity_envs["mash"]
     input:
         "references/all_complete_genomes.msh",

--- a/rules/mapping/find_closest_genomes.rules
+++ b/rules/mapping/find_closest_genomes.rules
@@ -2,7 +2,7 @@ rule sketch_kmers_complete_genomes_with_mash:
     conda:
         "../quality/env/mash.yml"
     container:
-        singularity_envs["mash"]
+        containers["mash"]
     input:
         "references/all_complete_genomes_log.txt"
     output:
@@ -16,7 +16,7 @@ rule calculate_distance_to_complete_genomes_with_mash:
     conda:
         "../quality/env/mash.yml"
     container:
-         singularity_envs["mash"]
+         containers["mash"]
     input:
         "references/all_complete_genomes.msh",
         "samples/{sample}/annotation/{sample}.fsa"

--- a/rules/mapping/indexing_files.rules
+++ b/rules/mapping/indexing_files.rules
@@ -1,7 +1,7 @@
 rule index_reference_fasta:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]
     input:
         "{any_genome}.{ext}"
@@ -17,7 +17,7 @@ rule index_reference_fasta:
 rule index_bam_file:
     conda:
         "../../envs/bwa-samtools.yml"
-    singularity:
+    container:
         singularity_envs["bwa_samtools"]
     input:
         "{any_bam}.bam"

--- a/rules/mapping/indexing_files.rules
+++ b/rules/mapping/indexing_files.rules
@@ -2,7 +2,7 @@ rule index_reference_fasta:
     conda:
         "../../envs/bwa-samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]
+        containers["bwa_samtools"]
     input:
         "{any_genome}.{ext}"
     output:
@@ -18,7 +18,7 @@ rule index_bam_file:
     conda:
         "../../envs/bwa-samtools.yml"
     container:
-        singularity_envs["bwa_samtools"]
+        containers["bwa_samtools"]
     input:
         "{any_bam}.bam"
     output:

--- a/rules/phylogeny/checkm.rules
+++ b/rules/phylogeny/checkm.rules
@@ -14,7 +14,7 @@ rule link_genomes_to_checkm_folder:
 rule checkm_analyse:
     conda:
         "../../envs/checkm.yml"
-    singularity:
+    container:
         singularity_envs["checkm"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
@@ -33,7 +33,7 @@ rule checkm_analyse:
 rule checkm_qa:
     conda:
         "../../envs/checkm.yml"
-    singularity:
+    container:
         singularity_envs["checkm"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
@@ -51,7 +51,7 @@ rule checkm_qa:
 rule checkm_markers:
     conda:
         "../../envs/checkm.yml"
-    singularity:
+    container:
         singularity_envs["checkm"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
@@ -69,7 +69,7 @@ rule checkm_markers:
 rule checkm_markers_fastas:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
@@ -86,7 +86,7 @@ rule checkm_markers_fastas:
 rule align_marker_fasta_with_mafft:
     conda:
         "../../envs/mafft.yml"
-    singularity:
+    container:
         singularity_envs["mafft"]
     input:
         fasta = "phylogeny/checkm/marker_fastas/{marker}.faa"
@@ -100,7 +100,7 @@ rule align_marker_fasta_with_mafft:
 rule concatenate_checkm_fastas:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         marker_fastas = dynamic("phylogeny/checkm/marker_alignments/{marker}_mafft.faa")
@@ -111,7 +111,7 @@ rule concatenate_checkm_fastas:
 rule build_phylogeny_with_fasttree:
     conda:
         "../../envs/fasttree.yml"
-    singularity:
+    container:
         singularity_envs["fasttree"]        
     input:
         alignment = "phylogeny/checkm/concatenated_alignment.faa"

--- a/rules/phylogeny/checkm.rules
+++ b/rules/phylogeny/checkm.rules
@@ -66,7 +66,7 @@ rule checkm_markers:
         checkm qa {params[0]} phylogeny/checkm/analyse -o 5 --tab_table > {output[0]}
         """
 
-rule checkm_markers_fastas:
+checkpoint checkm_markers_fastas:
     conda:
         "../../envs/python-r.yml"
     container:
@@ -79,11 +79,11 @@ rule checkm_markers_fastas:
         checkm_table = "phylogeny/checkm/analyse/markers.tab",
         checkm_fastas = expand("phylogeny/checkm/analyse/bins/{sample}/genes.fna", sample=read_naming.keys())
     output:
-        marker_fastas = dynamic("phylogeny/checkm/marker_fastas/{marker}.faa")
+        marker_fastas = "phylogeny/checkm/marker_fastas/{marker}.faa"
     script: "scripts/get_checkm_markers_fastas.py"
 
 
-rule align_marker_fasta_with_mafft:
+checkpoint align_marker_fasta_with_mafft:
     conda:
         "../../envs/mafft.yml"
     container:
@@ -103,7 +103,7 @@ rule concatenate_checkm_fastas:
     container:
         singularity_envs["python_r"]
     input:
-        marker_fastas = dynamic("phylogeny/checkm/marker_alignments/{marker}_mafft.faa")
+        marker_fastas = "phylogeny/checkm/marker_alignments/{marker}_mafft.faa"
     output:
         alignment = "phylogeny/checkm/concatenated_alignment.faa"
     script: "scripts/concat_align.py"

--- a/rules/phylogeny/checkm.rules
+++ b/rules/phylogeny/checkm.rules
@@ -15,7 +15,7 @@ rule checkm_analyse:
     conda:
         "../../envs/checkm.yml"
     container:
-        singularity_envs["checkm"]
+        containers["checkm"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
     threads:
@@ -34,7 +34,7 @@ rule checkm_qa:
     conda:
         "../../envs/checkm.yml"
     container:
-        singularity_envs["checkm"]
+        containers["checkm"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
     threads:
@@ -52,7 +52,7 @@ rule checkm_markers:
     conda:
         "../../envs/checkm.yml"
     container:
-        singularity_envs["checkm"]
+        containers["checkm"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
     threads:
@@ -70,7 +70,7 @@ checkpoint checkm_markers_fastas:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     params:
         markers = pipeline_path + 'configuration_files/data/checkm/bacteria.ms'
     threads:
@@ -87,7 +87,7 @@ checkpoint align_marker_fasta_with_mafft:
     conda:
         "../../envs/mafft.yml"
     container:
-        singularity_envs["mafft"]
+        containers["mafft"]
     input:
         fasta = "phylogeny/checkm/marker_fastas/{marker}.faa"
     output:
@@ -101,7 +101,7 @@ rule concatenate_checkm_fastas:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         marker_fastas = "phylogeny/checkm/marker_alignments/{marker}_mafft.faa"
     output:
@@ -112,7 +112,7 @@ rule build_phylogeny_with_fasttree:
     conda:
         "../../envs/fasttree.yml"
     container:
-        singularity_envs["fasttree"]        
+        containers["fasttree"]        
     input:
         alignment = "phylogeny/checkm/concatenated_alignment.faa"
     output:

--- a/rules/phylogeny/image_creation.rules
+++ b/rules/phylogeny/image_creation.rules
@@ -2,7 +2,7 @@ rule convert_phylogeny_to_image_with_st:
     conda:
         "../../envs/newick-utils.yml"
     container:
-        singularity_envs["newick_utils"]
+        containers["newick_utils"]
     params:
         size = config["phylogeny_image_size"]
     input:
@@ -26,7 +26,7 @@ rule convert_phylogeny_to_image_no_st:
     conda:
         "../../envs/newick-utils.yml"
     container:
-        singularity_envs["newick_utils"]  
+        containers["newick_utils"]  
     params:
         size = config["phylogeny_image_size"]
     input:

--- a/rules/phylogeny/image_creation.rules
+++ b/rules/phylogeny/image_creation.rules
@@ -1,7 +1,7 @@
 rule convert_phylogeny_to_image_with_st:
     conda:
         "../../envs/newick-utils.yml"
-    singularity:
+    container:
         singularity_envs["newick_utils"]
     params:
         size = config["phylogeny_image_size"]
@@ -25,7 +25,7 @@ rule convert_phylogeny_to_image_with_st:
 rule convert_phylogeny_to_image_no_st:
     conda:
         "../../envs/newick-utils.yml"
-    singularity:
+    container:
         singularity_envs["newick_utils"]  
     params:
         size = config["phylogeny_image_size"]

--- a/rules/phylogeny/raxml.rules
+++ b/rules/phylogeny/raxml.rules
@@ -2,7 +2,7 @@ rule compute_phylogeny_with_raxml:
     conda:
         "../../envs/raxml.yml"
     container:
-        singularity_envs["raxml"]
+        containers["raxml"]
     input:
         alignment="typing/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/alignment.fa"
     output:
@@ -24,7 +24,7 @@ rule compute_phylogeny_bootstraps_with_raxml:
     conda:
         "../../envs/raxml.yml"
     container:
-        singularity_envs["raxml"]
+        containers["raxml"]
     input:
         alignment = "typing/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/alignment.fa"
     output:

--- a/rules/phylogeny/raxml.rules
+++ b/rules/phylogeny/raxml.rules
@@ -1,7 +1,7 @@
 rule compute_phylogeny_with_raxml:
     conda:
         "../../envs/raxml.yml"
-    singularity:
+    container:
         singularity_envs["raxml"]
     input:
         alignment="typing/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/alignment.fa"
@@ -23,7 +23,7 @@ rule compute_phylogeny_with_raxml:
 rule compute_phylogeny_bootstraps_with_raxml:
     conda:
         "../../envs/raxml.yml"
-    singularity:
+    container:
         singularity_envs["raxml"]
     input:
         alignment = "typing/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/alignment.fa"

--- a/rules/quality/16S_check.rules
+++ b/rules/quality/16S_check.rules
@@ -16,7 +16,7 @@ if "16S_database" in config:
 
     rule extract_16S:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             "samples/{sample}/contamination/markers/rrna/{sample}_barrnap.ffn",
         output:
@@ -26,7 +26,7 @@ if "16S_database" in config:
 
     rule merge_16S:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             expand("samples/{sample}/contamination/markers/rrna/{sample}_barrnap_16S.ffn", sample=read_naming.keys()),
         output:
@@ -35,7 +35,7 @@ if "16S_database" in config:
 
     rule align_16S_with_mafft:
         container:
-            singularity_envs["mafft"]
+            containers["mafft"]
         input:
             "report/contamination/markers/rrna/merged_barrnap_16S.ffn",
         output:
@@ -47,7 +47,7 @@ if "16S_database" in config:
 
     rule calculate_parwise_identity:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             "report/contamination/markers/rrna/merged_barrnap_16S_mafft.ffn"
         output:
@@ -59,7 +59,7 @@ if "16S_database" in config:
 
     rule assign_taxonomy_vsearch:
         container:
-            singularity_envs["vsearch"]
+            containers["vsearch"]
         input:
             "samples/{sample}/contamination/markers/rrna/{sample}_barrnap_16S.ffn"
         output:
@@ -75,7 +75,7 @@ if "16S_database" in config:
 
     rule QIIME1_assign_taxonomy_rdp:
         container:
-            singularity_envs["rdp"] 
+            containers["rdp"] 
         input:
             "report/contamination/markers/rrna/merged_barrnap_16S.ffn",
             "/data/databases/amplicon_based_metagenomics/16S/ezbiocloud201805/QIIME/DB_amp.fasta",
@@ -101,7 +101,7 @@ if "16S_database" in config:
 
     rule assign_taxonomy_ssearch:
         container:
-            singularity_envs["fasta36"]
+            containers["fasta36"]
         container:
             "docker://quay.io/biocontainers/vsearch:2.15.0--h2d02072_0"
         input:
@@ -121,7 +121,7 @@ if "16S_database" in config:
 
     rule format_taxonomy_ssearch:
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             expand("report/contamination/markers/rrna/{sample}_ssearch.txt", sample=read_naming.keys())
         output:

--- a/rules/quality/16S_check.rules
+++ b/rules/quality/16S_check.rules
@@ -2,7 +2,7 @@
 if "16S_database" in config:
 
     rule extract_16S_with_barnap:
-        singularity:
+        container:
             "docker://quay.io/biocontainers/barrnap:0.9--3"
         input:
             "samples/{sample}/assembly/spades/contigs.fasta"
@@ -15,7 +15,7 @@ if "16S_database" in config:
             """
 
     rule extract_16S:
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             "samples/{sample}/contamination/markers/rrna/{sample}_barrnap.ffn",
@@ -25,7 +25,7 @@ if "16S_database" in config:
             "scripts/extract_16S.py"
 
     rule merge_16S:
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             expand("samples/{sample}/contamination/markers/rrna/{sample}_barrnap_16S.ffn", sample=read_naming.keys()),
@@ -34,7 +34,7 @@ if "16S_database" in config:
         script: "scripts/combine_16S.py"
 
     rule align_16S_with_mafft:
-        singularity:
+        container:
             singularity_envs["mafft"]
         input:
             "report/contamination/markers/rrna/merged_barrnap_16S.ffn",
@@ -46,7 +46,7 @@ if "16S_database" in config:
             """
 
     rule calculate_parwise_identity:
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             "report/contamination/markers/rrna/merged_barrnap_16S_mafft.ffn"
@@ -58,7 +58,7 @@ if "16S_database" in config:
 
 
     rule assign_taxonomy_vsearch:
-        singularity:
+        container:
             singularity_envs["vsearch"]
         input:
             "samples/{sample}/contamination/markers/rrna/{sample}_barrnap_16S.ffn"
@@ -74,7 +74,7 @@ if "16S_database" in config:
             """
 
     rule QIIME1_assign_taxonomy_rdp:
-        singularity:
+        container:
             singularity_envs["rdp"] 
         input:
             "report/contamination/markers/rrna/merged_barrnap_16S.ffn",
@@ -100,9 +100,9 @@ if "16S_database" in config:
 
 
     rule assign_taxonomy_ssearch:
-        singularity:
+        container:
             singularity_envs["fasta36"]
-        singularity:
+        container:
             "docker://quay.io/biocontainers/vsearch:2.15.0--h2d02072_0"
         input:
             "samples/{sample}/contamination/markers/rrna/{sample}_barrnap_16S.ffn",
@@ -120,7 +120,7 @@ if "16S_database" in config:
 
 
     rule format_taxonomy_ssearch:
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             expand("report/contamination/markers/rrna/{sample}_ssearch.txt", sample=read_naming.keys())

--- a/rules/quality/assembly_filtering.rules
+++ b/rules/quality/assembly_filtering.rules
@@ -58,8 +58,8 @@ rule extract_contigs_longer_than_500bp:
         "samples/{sample}/assembly/spades/contigs_500bp.fasta"
     shell:
         """
-        awk '/^>/ {print (NR==1)?$0: "\\n" $0;next} {printf "%s", $0} END {print ""}' {input} | \
-        awk '!/^>/ { next } { getline seq } length(seq) >= 500 { print $0 "\\n" seq }' > {output}
+        awk '/^>/ {{print (NR==1)?$0: "\\n" $0;next}} {{printf "%s", $0}} END {{print ""}}' {input} | \
+        awk '!/^>/ {{ next }} {{ getline seq }} length(seq) >= 500 {{ print $0 "\\n" seq }}' > {output}
         """
 
 

--- a/rules/quality/assembly_filtering.rules
+++ b/rules/quality/assembly_filtering.rules
@@ -35,7 +35,7 @@ rule extract_assembly_mean_sd_coverage:
 # 
 rule filter_contigs_on_coverage:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     params:
         depth_cutoff = config["cov_cutoff"],
         length_cutoff = config["length_cutoff"]
@@ -57,7 +57,10 @@ rule extract_contigs_longer_than_500bp:
     output:
         "samples/{sample}/assembly/spades/contigs_500bp.fasta"
     shell:
-        "awk '/^>/{{print (NR==1)?$0: \"\\n\" $0;next}} {{printf \"%s\", $0}}END{{print \"\"}}' {input} |  awk \'!/^>/ {{ next }} {{ getline seq }} length(seq) >= 500 {{ print $0 \"\\n\" seq }}\'  > {output}"
+        """
+        awk '/^>/ {print (NR==1)?$0: "\\n" $0;next} {printf "%s", $0} END {print ""}' {input} | \
+        awk '!/^>/ { next } { getline seq } length(seq) >= 500 { print $0 "\\n" seq }' > {output}
+        """
 
 
 rule rename_contigs:
@@ -66,4 +69,6 @@ rule rename_contigs:
     output:
         "samples/{sample}/assembly/spades/contigs_500bp_renamed.fasta"
     shell:
-        "sed \"s/NODE_\\([0-9]\\+\\)_.*/contig_\\1/\" {input} > {output}"
+        """
+        sed "s/NODE_\\([0-9]\\+\\)_.*/contig_\\1/" {input} > {output}
+        """

--- a/rules/quality/assembly_filtering.rules
+++ b/rules/quality/assembly_filtering.rules
@@ -49,18 +49,7 @@ rule filter_contigs_on_coverage:
         logging_folder+"contig_filtering/{mapping_method}/{sample}.log"
     script: "scripts/filter_contigs.py"
 
-'''
-rule prepare_low_coverage_contigs_report:
-    conda:
-        "../../envs/report.yml"
-    input:
-        low_depth_contigs = expand('')
-        assembly_depth = expand('samples/{sample}/quality/assembly_coverage.txt', sample=reads_naming.keys())
-    output:
-        low_cov_fastas = expand("samples/{sample}/assembly/spades/coverage_filtered/contigs_500bp_low_coverage.fasta", sample=read_naming.keys()),
-    script:
-        "script/report_lowcov_contigs.py"
-'''
+
 
 rule extract_contigs_longer_than_500bp:
     input:

--- a/rules/quality/assembly_filtering.rules
+++ b/rules/quality/assembly_filtering.rules
@@ -34,7 +34,7 @@ rule extract_assembly_mean_sd_coverage:
 
 # 
 rule filter_contigs_on_coverage:
-    singularity:
+    container:
         singularity_envs["python_r"]
     params:
         depth_cutoff = config["cov_cutoff"],

--- a/rules/quality/checkm.rules
+++ b/rules/quality/checkm.rules
@@ -2,7 +2,7 @@
 
 rule checkm_lineage_wf:
     container:
-        singularity_envs["checkm"]
+        containers["checkm"]
     input:
         expand("report/assemblies_filtered/{sample}.fna", sample=read_naming.keys())
     output:
@@ -17,7 +17,7 @@ rule checkm_lineage_wf:
 
 rule checkm_qc:
     container:
-        singularity_envs["checkm"]
+        containers["checkm"]
     input:
         "checkm/analyse_wf/lineage.ms"
     output:
@@ -31,7 +31,7 @@ rule checkm_qc:
 
 rule checkm_marker_genes:
     container:
-        singularity_envs["checkm"]
+        containers["checkm"]
     input:
         "checkm/analyse_wf/lineage.ms"
     output:

--- a/rules/quality/checkm.rules
+++ b/rules/quality/checkm.rules
@@ -11,7 +11,6 @@ rule checkm_lineage_wf:
         16
     shell:
         """
-        # checkm taxonomy_wf -t {threads} domain Bacteria report/assemblies_filtered checkm/analyse_wf
         checkm lineage_wf -t {threads} report/assemblies_filtered checkm/analyse_wf
         """
 

--- a/rules/quality/checkm.rules
+++ b/rules/quality/checkm.rules
@@ -1,7 +1,7 @@
 
 
 rule checkm_lineage_wf:
-    singularity:
+    container:
         singularity_envs["checkm"]
     input:
         expand("report/assemblies_filtered/{sample}.fna", sample=read_naming.keys())
@@ -16,7 +16,7 @@ rule checkm_lineage_wf:
         """
 
 rule checkm_qc:
-    singularity:
+    container:
         singularity_envs["checkm"]
     input:
         "checkm/analyse_wf/lineage.ms"
@@ -30,7 +30,7 @@ rule checkm_qc:
         """
 
 rule checkm_marker_genes:
-    singularity:
+    container:
         singularity_envs["checkm"]
     input:
         "checkm/analyse_wf/lineage.ms"

--- a/rules/quality/contamination.rules
+++ b/rules/quality/contamination.rules
@@ -159,9 +159,9 @@ rule convert_centrifuge_to_kraken_output:
     threads:
         2
     conda:
-        containers["centrifuge"]
+        "../../envs/centrifuge.yml"
     container:
-        "docker://quay.io/biocontainers/centrifuge:1.0.4_beta--he860b03_3"
+        containers["centrifuge"]
     input:
         detail = "samples/{sample}/contamination/centrifuge/results.tsv",
         database = "references/centrifuge_db/p_compressed+h+v.1.cf"

--- a/rules/quality/contamination.rules
+++ b/rules/quality/contamination.rules
@@ -5,7 +5,7 @@ rule calculate_distance_paired_reads_from_refseq_genomes_with_mash:
     conda:
         "../../envs/mash.yml"
     container:
-        singularity_envs["mash"]
+        containers["mash"]
     threads:
         2
     input:
@@ -27,7 +27,7 @@ rule calculate_distance_assembly_from_refseq_genomes_with_mash:
     conda:
         "../../envs/mash.yml"
     container:
-        singularity_envs["mash"]
+        containers["mash"]
     input:
         mash_sketch = "references/mash_sketch.msh",
         assembly = "samples/{sample}/assembly/spades/contigs_500bp_renamed.fasta",
@@ -46,7 +46,7 @@ rule calculate_distance_single_reads_from_refseq_genomes_with_mash:
     conda:
         "../../envs/mash.yml"
     container:
-        singularity_envs["mash"]
+        containers["mash"]
     input:
         mash_sketch = "references/mash_sketch.msh",
         single = "samples/{sample}/reads/raw/single_{sample}.fastq.gz",
@@ -63,7 +63,7 @@ rule get_taxonomy_from_mash_results:
     conda:
         "../../envs/entrez-direct.yml"
     container:
-        singularity_envs["entrez-direct"]
+        containers["entrez-direct"]
     input:
         distances = "samples/{sample}/contamination/mash/{fastq_or_assembly}/distances.tsv"
     output:
@@ -91,7 +91,7 @@ rule format_tsv_to_xlsx_mash_results:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         tsv = "samples/{sample}/contamination/mash/{fastq_or_assembly}/{results}.tsv",
     output:
@@ -104,7 +104,7 @@ rule merge_all_xlsx_mash_results:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         xlsx = expand("samples/{sample}/contamination/mash/{{fastq_or_assembly}}/{{results}}.xlsx", sample=read_naming.keys())
     output:
@@ -122,7 +122,7 @@ rule paired_reads_classification_with_centrifuge:
     conda:
         "../../envs/centrifuge.yml"
     container:
-        singularity_envs["centrifuge"]
+        containers["centrifuge"]
     input:
         R1_trimmed = "samples/{sample}/reads/trimmed/R1_paired.fastq",
         R2_trimmed = "samples/{sample}/reads/trimmed/R2_paired.fastq",
@@ -140,7 +140,7 @@ rule single_reads_classification_with_centrifuge:
     threads:
         2
     conda:
-        singularity_envs["centrifuge"]
+        containers["centrifuge"]
     container:
         "docker://quay.io/biocontainers/centrifuge:1.0.4_beta--he860b03_3"
     input:
@@ -159,7 +159,7 @@ rule convert_centrifuge_to_kraken_output:
     threads:
         2
     conda:
-        singularity_envs["centrifuge"]
+        containers["centrifuge"]
     container:
         "docker://quay.io/biocontainers/centrifuge:1.0.4_beta--he860b03_3"
     input:
@@ -177,7 +177,7 @@ rule format_centrifuge_kraken:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         report = "report/contamination/centrifuge/{sample}/centrifuge_kraken_format.txt",
     output:
@@ -189,7 +189,7 @@ rule format_centrifuge_output:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         report = "samples/{sample}/contamination/centrifuge/report.tsv",
         detail = "samples/{sample}/contamination/centrifuge/results.tsv",

--- a/rules/quality/contamination.rules
+++ b/rules/quality/contamination.rules
@@ -4,7 +4,7 @@ ruleorder: calculate_distance_paired_reads_from_refseq_genomes_with_mash > calcu
 rule calculate_distance_paired_reads_from_refseq_genomes_with_mash:
     conda:
         "../../envs/mash.yml"
-    singularity:
+    container:
         singularity_envs["mash"]
     threads:
         2
@@ -26,7 +26,7 @@ rule calculate_distance_assembly_from_refseq_genomes_with_mash:
         2
     conda:
         "../../envs/mash.yml"
-    singularity:
+    container:
         singularity_envs["mash"]
     input:
         mash_sketch = "references/mash_sketch.msh",
@@ -45,7 +45,7 @@ rule calculate_distance_single_reads_from_refseq_genomes_with_mash:
         2
     conda:
         "../../envs/mash.yml"
-    singularity:
+    container:
         singularity_envs["mash"]
     input:
         mash_sketch = "references/mash_sketch.msh",
@@ -62,7 +62,7 @@ rule calculate_distance_single_reads_from_refseq_genomes_with_mash:
 rule get_taxonomy_from_mash_results:
     conda:
         "../../envs/entrez-direct.yml"
-    singularity:
+    container:
         singularity_envs["entrez-direct"]
     input:
         distances = "samples/{sample}/contamination/mash/{fastq_or_assembly}/distances.tsv"
@@ -90,7 +90,7 @@ rule format_distances_from_mash_results:
 rule format_tsv_to_xlsx_mash_results:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         tsv = "samples/{sample}/contamination/mash/{fastq_or_assembly}/{results}.tsv",
@@ -103,7 +103,7 @@ rule format_tsv_to_xlsx_mash_results:
 rule merge_all_xlsx_mash_results:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         xlsx = expand("samples/{sample}/contamination/mash/{{fastq_or_assembly}}/{{results}}.xlsx", sample=read_naming.keys())
@@ -121,7 +121,7 @@ rule paired_reads_classification_with_centrifuge:
         2
     conda:
         "../../envs/centrifuge.yml"
-    singularity:
+    container:
         singularity_envs["centrifuge"]
     input:
         R1_trimmed = "samples/{sample}/reads/trimmed/R1_paired.fastq",
@@ -141,7 +141,7 @@ rule single_reads_classification_with_centrifuge:
         2
     conda:
         singularity_envs["centrifuge"]
-    singularity:
+    container:
         "docker://quay.io/biocontainers/centrifuge:1.0.4_beta--he860b03_3"
     input:
         single = "samples/{sample}/reads/raw/single_{sample}.fastq.gz",
@@ -160,7 +160,7 @@ rule convert_centrifuge_to_kraken_output:
         2
     conda:
         singularity_envs["centrifuge"]
-    singularity:
+    container:
         "docker://quay.io/biocontainers/centrifuge:1.0.4_beta--he860b03_3"
     input:
         detail = "samples/{sample}/contamination/centrifuge/results.tsv",
@@ -176,7 +176,7 @@ rule convert_centrifuge_to_kraken_output:
 rule format_centrifuge_kraken:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         report = "report/contamination/centrifuge/{sample}/centrifuge_kraken_format.txt",
@@ -188,7 +188,7 @@ rule format_centrifuge_kraken:
 rule format_centrifuge_output:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         report = "samples/{sample}/contamination/centrifuge/report.tsv",

--- a/rules/quality/trimmomatic.rules
+++ b/rules/quality/trimmomatic.rules
@@ -9,7 +9,7 @@ rule trim_paired_reads_with_trimmomatic:
         "samples/{sample}/reads/raw/{sample}_R1.fastq.gz",
         "samples/{sample}/reads/raw/{sample}_R2.fastq.gz"
     params:
-        conda_path = workflow.conda_prefix,
+        conda_path = workflow.deployment_settings.conda_prefix,
         minlength = config["minimum_read_length"],
         minqual = config["minimum_quality_base"],
         adapter_file_name = config["adapter_file_name"],
@@ -42,7 +42,7 @@ rule trim_single_reads_with_trimmomatic:
     input:
         "samples/{sample}/reads/raw/single_{sample}.fastq.gz"
     params:
-        conda_path = workflow.conda_prefix,
+        conda_path = workflow.deployment_settings.conda_prefix,
         minlength = config["minimum_read_length"],
         minqual = config["minimum_quality_base"],
         adapter_file_name = config["adapter_file_name"],

--- a/rules/quality/trimmomatic.rules
+++ b/rules/quality/trimmomatic.rules
@@ -4,7 +4,7 @@ rule trim_paired_reads_with_trimmomatic:
     conda:
         "../../envs/trimmomatic.yml"
     container:
-        singularity_envs["trimmomatic"]        
+        containers["trimmomatic"]        
     input:
         "samples/{sample}/reads/raw/{sample}_R1.fastq.gz",
         "samples/{sample}/reads/raw/{sample}_R2.fastq.gz"
@@ -38,7 +38,7 @@ rule trim_single_reads_with_trimmomatic:
     conda:
         "../../envs/trimmomatic.yml"
     container:
-        singularity_envs["trimmomatic"]
+        containers["trimmomatic"]
     input:
         "samples/{sample}/reads/raw/single_{sample}.fastq.gz"
     params:

--- a/rules/quality/trimmomatic.rules
+++ b/rules/quality/trimmomatic.rules
@@ -3,7 +3,7 @@ ruleorder: trim_paired_reads_with_trimmomatic > trim_single_reads_with_trimmomat
 rule trim_paired_reads_with_trimmomatic:
     conda:
         "../../envs/trimmomatic.yml"
-    singularity:
+    container:
         singularity_envs["trimmomatic"]        
     input:
         "samples/{sample}/reads/raw/{sample}_R1.fastq.gz",
@@ -37,7 +37,7 @@ rule trim_paired_reads_with_trimmomatic:
 rule trim_single_reads_with_trimmomatic:
     conda:
         "../../envs/trimmomatic.yml"
-    singularity:
+    container:
         singularity_envs["trimmomatic"]
     input:
         "samples/{sample}/reads/raw/single_{sample}.fastq.gz"

--- a/rules/read_manipulation/get_sras.rules
+++ b/rules/read_manipulation/get_sras.rules
@@ -7,7 +7,7 @@
 rule download_sra:
     conda:
         "../../envs/sra-tools.yml"
-    singularity:
+    container:
         singularity_envs["sra-toolkit"]
     output:
         # /home/pipeline_user/ncbi/public: % os.getenv("HOME")
@@ -26,7 +26,7 @@ rule download_sra:
 rule sra_convert_to_fastq_paired:
     conda:
         "../../envs/sra-tools.yml"
-    singularity:
+    container:
         singularity_envs["sra-toolkit"]
     input:
         # "%s/ncbi/public/sra/{sample}.sra" % os.getenv("HOME"),
@@ -44,7 +44,7 @@ rule sra_convert_to_fastq_paired:
 rule sra_convert_to_fastq_single:
     conda:
         "../../envs/sra-tools.yml"
-    singularity:
+    container:
         singularity_envs["sra-toolkit"]
     input:
         # "%s/ncbi/public/sra/{sample}.sra" % os.getenv("HOME")

--- a/rules/read_manipulation/get_sras.rules
+++ b/rules/read_manipulation/get_sras.rules
@@ -8,7 +8,7 @@ rule download_sra:
     conda:
         "../../envs/sra-tools.yml"
     container:
-        singularity_envs["sra-toolkit"]
+        containers["sra-toolkit"]
     output:
         # /home/pipeline_user/ncbi/public: % os.getenv("HOME")
         temp("ncbi/public/sra/{sample}.sra" ),
@@ -27,7 +27,7 @@ rule sra_convert_to_fastq_paired:
     conda:
         "../../envs/sra-tools.yml"
     container:
-        singularity_envs["sra-toolkit"]
+        containers["sra-toolkit"]
     input:
         # "%s/ncbi/public/sra/{sample}.sra" % os.getenv("HOME"),
         "ncbi/public/sra/{sample}.sra",
@@ -45,7 +45,7 @@ rule sra_convert_to_fastq_single:
     conda:
         "../../envs/sra-tools.yml"
     container:
-        singularity_envs["sra-toolkit"]
+        containers["sra-toolkit"]
     input:
         # "%s/ncbi/public/sra/{sample}.sra" % os.getenv("HOME")
         "ncbi/public/sra/{sample}.sra",

--- a/rules/read_manipulation/merge_paired_reads.rules
+++ b/rules/read_manipulation/merge_paired_reads.rules
@@ -3,7 +3,7 @@ rule merge_reads_with_flash:
     conda:
         "../../envs/flash.yml"
     container:
-        singularity_envs["flash"]
+        containers["flash"]
     input:
         "samples/{sample}/reads/raw/{sample}_R1.fastq.gz",
         "samples/{sample}/reads/raw/{sample}_R2.fastq.gz"

--- a/rules/read_manipulation/merge_paired_reads.rules
+++ b/rules/read_manipulation/merge_paired_reads.rules
@@ -2,7 +2,7 @@
 rule merge_reads_with_flash:
     conda:
         "../../envs/flash.yml"
-    singularity:
+    container:
         singularity_envs["flash"]
     input:
         "samples/{sample}/reads/raw/{sample}_R1.fastq.gz",

--- a/rules/report_generation/collect_statistics.rules
+++ b/rules/report_generation/collect_statistics.rules
@@ -1,7 +1,7 @@
 rule statistics:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         multiqc_assembly = "report/multiqc_assembly_flash/multiqc_data/multiqc_data.json",
@@ -22,7 +22,7 @@ rule statistics:
 rule statistics_assembly:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         multiqc_assembly = "report/multiqc_assembly/multiqc_data/multiqc_data.json",
@@ -40,7 +40,7 @@ rule statistics_assembly:
 rule statistics_minimal:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         #contigs = expand("samples/{sample}/assembly/spades/contigs.fasta", sample=read_naming.keys()),

--- a/rules/report_generation/collect_statistics.rules
+++ b/rules/report_generation/collect_statistics.rules
@@ -2,7 +2,7 @@ rule statistics:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         multiqc_assembly = "report/multiqc_assembly_flash/multiqc_data/multiqc_data.json",
         fastg_assembly = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
@@ -23,7 +23,7 @@ rule statistics_assembly:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         multiqc_assembly = "report/multiqc_assembly/multiqc_data/multiqc_data.json",
         fastg_assembly = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
@@ -41,7 +41,7 @@ rule statistics_minimal:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         #contigs = expand("samples/{sample}/assembly/spades/contigs.fasta", sample=read_naming.keys()),
         #contigs_depth = expand("samples/{sample}/{mapping_method}/{sample}_assembled_genome/contig_coverage.txt", sample=read_naming.keys(), mapping_method=config["mapping"]),

--- a/rules/report_generation/collect_statistics.rules
+++ b/rules/report_generation/collect_statistics.rules
@@ -5,7 +5,7 @@ rule statistics:
         singularity_envs["python_r"]
     input:
         multiqc_assembly = "report/multiqc_assembly_flash/multiqc_data/multiqc_data.json",
-	    fastg_assembly = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
+        fastg_assembly = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
         contigs = expand("samples/{sample}/assembly/spades/contigs.fasta", sample=read_naming.keys()),
         contigs_depth = expand("samples/{sample}/{mapping_method}/{sample}_assembled_genome/contig_coverage.txt", sample=read_naming.keys(), mapping_method=config["mapping"]),
         mash_results = expand('samples/{sample}/contamination/mash/assembly/distances_formated.tsv', sample=read_naming.keys()),

--- a/rules/report_generation/contamination.rules
+++ b/rules/report_generation/contamination.rules
@@ -3,7 +3,7 @@ rule mash_report:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         mash_results = "samples/{sample}/contamination/mash/{fastq_or_assembly}/distances.tsv",
     params:
@@ -16,7 +16,7 @@ rule low_coverage_contig_report:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         low_cov_contigs_fasta = "samples/{sample}/assembly/spades/coverage_filtered/bwa/contigs_500bp_low_coverage.fasta",
     output:

--- a/rules/report_generation/contamination.rules
+++ b/rules/report_generation/contamination.rules
@@ -2,7 +2,7 @@
 rule mash_report:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         mash_results = "samples/{sample}/contamination/mash/{fastq_or_assembly}/distances.tsv",
@@ -15,7 +15,7 @@ rule mash_report:
 rule low_coverage_contig_report:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         low_cov_contigs_fasta = "samples/{sample}/assembly/spades/coverage_filtered/bwa/contigs_500bp_low_coverage.fasta",

--- a/rules/report_generation/ete_figures.rules
+++ b/rules/report_generation/ete_figures.rules
@@ -4,7 +4,7 @@ if "virulence_factors" in config:
         conda:
             "../../envs/pandas-ete3-matplotlib.yml",
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             nr_blast_results=expand("samples/{sample}/virulence/results_blast_not_redundant.tsv", sample = read_naming.keys()),
             best_tree = "phylogeny/gatk_gvcfs/cgMLST/bwa/normal_run/RAxML_bestTree.nw",
@@ -18,7 +18,7 @@ if "virulence_factors" in config:
         conda:
             "../../envs/pandas-ete3-matplotlib.yml",
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             nr_blast_results=expand("samples/{sample}/virulence/results_blast_not_redundant.tsv", sample = read_naming.keys()),
             best_tree = "phylogeny/checkm/tree.nwk",
@@ -38,7 +38,7 @@ rule plot_MLST_ete_tree:
     conda:
         "../../envs/pandas-ete3-matplotlib.yml",
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         best_tree = "phylogeny/gatk_gvcfs/cgMLST/bwa/normal_run/RAxML_bestTree.nw",
         mlst='report/typing/mlst/summary.tsv',
@@ -51,7 +51,7 @@ rule plot_VFDB_ete_tree_counts:
     conda:
         "../../envs/pandas-ete3-matplotlib.yml",
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         blast_results=expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),
         best_tree = "phylogeny/gatk_gvcfs/cgMLST/bwa/normal_run/RAxML_bestTree.nw",
@@ -67,7 +67,7 @@ rule plot_VFDB_ete_matrix:
     conda:
         "../../envs/pandas-ete3-matplotlib.yml",
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         blast_results=expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),
         best_tree = "phylogeny/gatk_gvcfs/cgMLST/bwa/normal_run/RAxML_bestTree.nw",

--- a/rules/report_generation/ete_figures.rules
+++ b/rules/report_generation/ete_figures.rules
@@ -3,7 +3,7 @@ if "virulence_factors" in config:
     rule plot_virulence_ete_tree:
         conda:
             "../../envs/pandas-ete3-matplotlib.yml",
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             nr_blast_results=expand("samples/{sample}/virulence/results_blast_not_redundant.tsv", sample = read_naming.keys()),
@@ -17,7 +17,7 @@ if "virulence_factors" in config:
     rule plot_virulence_ete_tree_s_aureus:
         conda:
             "../../envs/pandas-ete3-matplotlib.yml",
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             nr_blast_results=expand("samples/{sample}/virulence/results_blast_not_redundant.tsv", sample = read_naming.keys()),
@@ -37,7 +37,7 @@ if "virulence_factors" in config:
 rule plot_MLST_ete_tree:
     conda:
         "../../envs/pandas-ete3-matplotlib.yml",
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         best_tree = "phylogeny/gatk_gvcfs/cgMLST/bwa/normal_run/RAxML_bestTree.nw",
@@ -50,7 +50,7 @@ rule plot_MLST_ete_tree:
 rule plot_VFDB_ete_tree_counts:
     conda:
         "../../envs/pandas-ete3-matplotlib.yml",
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         blast_results=expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),
@@ -66,7 +66,7 @@ rule plot_VFDB_ete_tree_counts:
 rule plot_VFDB_ete_matrix:
     conda:
         "../../envs/pandas-ete3-matplotlib.yml",
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         blast_results=expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),

--- a/rules/report_generation/fastqc.rules
+++ b/rules/report_generation/fastqc.rules
@@ -2,7 +2,7 @@ rule assess_quality_single_reads_with_fastqc:
     conda:
         "../../envs/fastqc.yml"
     container:
-        singularity_envs["fastqc"]
+        containers["fastqc"]
     input:
         "samples/{sample}/reads/trimmed/single.fastq",
     output:
@@ -18,7 +18,7 @@ rule assess_quality_paired_reads_with_fastqc:
     conda:
         "../../envs/fastqc.yml"
     container:
-        singularity_envs["fastqc"]
+        containers["fastqc"]
     input:
         "samples/{sample}/reads/trimmed/R1_paired.fastq",
         "samples/{sample}/reads/trimmed/R2_paired.fastq"

--- a/rules/report_generation/fastqc.rules
+++ b/rules/report_generation/fastqc.rules
@@ -1,7 +1,7 @@
 rule assess_quality_single_reads_with_fastqc:
     conda:
         "../../envs/fastqc.yml"
-    singularity:
+    container:
         singularity_envs["fastqc"]
     input:
         "samples/{sample}/reads/trimmed/single.fastq",
@@ -17,7 +17,7 @@ rule assess_quality_single_reads_with_fastqc:
 rule assess_quality_paired_reads_with_fastqc:
     conda:
         "../../envs/fastqc.yml"
-    singularity:
+    container:
         singularity_envs["fastqc"]
     input:
         "samples/{sample}/reads/trimmed/R1_paired.fastq",

--- a/rules/report_generation/general_report.rules
+++ b/rules/report_generation/general_report.rules
@@ -22,7 +22,7 @@ if "strain_characterization" in sys.argv:
         rule report_strain_characterization:
             conda:
                 "../../envs/python-r.yml"
-            singularity:
+            container:
                 singularity_envs["python_r"]
             input:
                 virulence_reports = expand("report/virulence/VFDB/{sample}_report.html", sample=read_naming.keys()),
@@ -49,7 +49,7 @@ if "strain_characterization" in sys.argv:
         rule report_strain_characterization:
             conda:
                 "../../envs/python-r.yml"
-            singularity:
+            container:
                 singularity_envs["python_r"]
             input:
                 virulence_reports = expand("report/virulence/VFDB/{sample}_report.html", sample=read_naming.keys()),

--- a/rules/report_generation/general_report.rules
+++ b/rules/report_generation/general_report.rules
@@ -23,7 +23,7 @@ if "strain_characterization" in sys.argv:
             conda:
                 "../../envs/python-r.yml"
             container:
-                singularity_envs["python_r"]
+                containers["python_r"]
             input:
                 virulence_reports = expand("report/virulence/VFDB/{sample}_report.html", sample=read_naming.keys()),
                 blast_results = expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),
@@ -50,7 +50,7 @@ if "strain_characterization" in sys.argv:
             conda:
                 "../../envs/python-r.yml"
             container:
-                singularity_envs["python_r"]
+                containers["python_r"]
             input:
                 virulence_reports = expand("report/virulence/VFDB/{sample}_report.html", sample=read_naming.keys()),
                 blast_results = expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),

--- a/rules/report_generation/multiqc.rules
+++ b/rules/report_generation/multiqc.rules
@@ -3,7 +3,7 @@ rule create_multiqc_report_for_assembly:
         configfile = multiqc_configfile
     conda:
         "../../envs/multiqc.yml"
-    singularity:
+    container:
         singularity_envs["multiqc"]        
     input:
         assembly=expand("samples/{sample}/multiqc/assembly/log.txt", sample = list(read_naming.keys())),
@@ -23,7 +23,7 @@ rule create_multiqc_report_for_assembly_and_flash:
         configfile = multiqc_configfile
     conda:
         "../../envs/multiqc.yml"
-    singularity:
+    container:
         singularity_envs["multiqc"]          
     input:
         assembly=expand("samples/{sample}/multiqc/assembly/log_flash.txt", sample = list(read_naming.keys())),
@@ -44,7 +44,7 @@ rule create_multiqc_report_for_mapping:
         configfile = multiqc_configfile
     conda:
         "../../envs/multiqc.yml"
-    singularity:
+    container:
         singularity_envs["multiqc"]  
     input:
         mapping = expand("samples/{sample}/multiqc/mapping_to_{{ref}}/{{mapping_method}}/log.txt", sample = list(read_naming.keys())),

--- a/rules/report_generation/multiqc.rules
+++ b/rules/report_generation/multiqc.rules
@@ -4,7 +4,7 @@ rule create_multiqc_report_for_assembly:
     conda:
         "../../envs/multiqc.yml"
     container:
-        singularity_envs["multiqc"]        
+        containers["multiqc"]        
     input:
         assembly=expand("samples/{sample}/multiqc/assembly/log.txt", sample = list(read_naming.keys())),
         mapping=expand("samples/{sample}/multiqc/mapping_to_{sample}_assembled_genome/bwa/log.txt", sample = list(read_naming.keys())),
@@ -24,7 +24,7 @@ rule create_multiqc_report_for_assembly_and_flash:
     conda:
         "../../envs/multiqc.yml"
     container:
-        singularity_envs["multiqc"]          
+        containers["multiqc"]          
     input:
         assembly=expand("samples/{sample}/multiqc/assembly/log_flash.txt", sample = list(read_naming.keys())),
         mapping=expand("samples/{sample}/multiqc/mapping_to_{sample}_assembled_genome/bwa/log.txt", sample = list(read_naming.keys())),
@@ -45,7 +45,7 @@ rule create_multiqc_report_for_mapping:
     conda:
         "../../envs/multiqc.yml"
     container:
-        singularity_envs["multiqc"]  
+        containers["multiqc"]  
     input:
         mapping = expand("samples/{sample}/multiqc/mapping_to_{{ref}}/{{mapping_method}}/log.txt", sample = list(read_naming.keys())),
     output:

--- a/rules/report_generation/qualimap.rules
+++ b/rules/report_generation/qualimap.rules
@@ -1,7 +1,7 @@
 rule assess_mapping_with_qualimap:
     conda:
         "../../envs/qualimap.yml"
-    singularity:
+    container:
         singularity_envs["qualimap"]     
     input:
         # samples/{sample}/mapping/bwa/{ref}.bam

--- a/rules/report_generation/qualimap.rules
+++ b/rules/report_generation/qualimap.rules
@@ -2,7 +2,7 @@ rule assess_mapping_with_qualimap:
     conda:
         "../../envs/qualimap.yml"
     container:
-        singularity_envs["qualimap"]     
+        containers["qualimap"]     
     input:
         # samples/{sample}/mapping/bwa/{ref}.bam
         bam = "samples/{sample}/mapping/{mapping_method}/{ref}.bam",

--- a/rules/report_generation/quast.rules
+++ b/rules/report_generation/quast.rules
@@ -2,7 +2,7 @@
 rule calculate_assembly_statistics_with_quast:
     conda:
         "../../envs/quast.yml"
-    singularity:
+    container:
         singularity_envs["quast"] 
     input:
         "samples/{sample}/annotation/{sample}.fna"

--- a/rules/report_generation/quast.rules
+++ b/rules/report_generation/quast.rules
@@ -3,7 +3,7 @@ rule calculate_assembly_statistics_with_quast:
     conda:
         "../../envs/quast.yml"
     container:
-        singularity_envs["quast"] 
+        containers["quast"] 
     input:
         "samples/{sample}/annotation/{sample}.fna"
     output:

--- a/rules/report_generation/report_epidemiology.rules
+++ b/rules/report_generation/report_epidemiology.rules
@@ -7,7 +7,7 @@ if "epidemiology" in sys.argv:
         conda:
             "../../envs/python-r.yml"
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             multiqc_report = "report/multiqc_assembly/multiqc_report.html",
             ete_figure = "report/figures/virulence_staph.svg",
@@ -121,7 +121,7 @@ if "epidemiology" in sys.argv:
         conda:
             "../../envs/python-r.yml"
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             qualimap_reports = get_qualimap_file_list(read_naming.keys(), reference_genomes_dir, config["mapping"]),
             multiqc_mapping_list = get_multiqc_list(config["mapping"], reference_genomes_dir, species),
@@ -149,7 +149,7 @@ if "epidemiology" in sys.argv:
         conda:
             "../../envs/python-r.yml"
         container:
-            singularity_envs["python_r"]
+            containers["python_r"]
         input:
             multiqc_report = "report/multiqc_assembly/multiqc_report.html",
             ete_figure_counts = "report/figures/virulence_counts.svg",

--- a/rules/report_generation/report_epidemiology.rules
+++ b/rules/report_generation/report_epidemiology.rules
@@ -6,7 +6,7 @@ if "epidemiology" in sys.argv:
     rule report_epidemiology_virulence_resistance_saureus:
         conda:
             "../../envs/python-r.yml"
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             multiqc_report = "report/multiqc_assembly/multiqc_report.html",
@@ -120,7 +120,7 @@ if "epidemiology" in sys.argv:
     rule report_epidemiology:
         conda:
             "../../envs/python-r.yml"
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             qualimap_reports = get_qualimap_file_list(read_naming.keys(), reference_genomes_dir, config["mapping"]),
@@ -148,7 +148,7 @@ if "epidemiology" in sys.argv:
     rule report_epidemiology_virulence_resistance:
         conda:
             "../../envs/python-r.yml"
-        singularity:
+        container:
             singularity_envs["python_r"]
         input:
             multiqc_report = "report/multiqc_assembly/multiqc_report.html",

--- a/rules/report_generation/report_resistance.rules
+++ b/rules/report_generation/report_resistance.rules
@@ -39,7 +39,7 @@ if "resistance" in sys.argv:
     rule report_resistance:
         conda:
             singularity_envs["python_r"]
-        singularity:
+        container:
             "docker://metagenlab/diag-pipeline-python-r:1.1"
         input:
             unpack(resistance_input)
@@ -54,7 +54,7 @@ if "resistance" in sys.argv:
 
 
 rule resistance_detailed_table:
-    singularity:
+    container:
         singularity_envs["python_r"]   
     input:
         res_files=expand("samples/{sample}/resistance/combined_{sample}.tsv", sample=read_naming.keys()),

--- a/rules/report_generation/report_resistance.rules
+++ b/rules/report_generation/report_resistance.rules
@@ -38,7 +38,7 @@ if "resistance" in sys.argv:
 
     rule report_resistance:
         conda:
-            singularity_envs["python_r"]
+            containers["python_r"]
         container:
             "docker://metagenlab/diag-pipeline-python-r:1.1"
         input:
@@ -55,7 +55,7 @@ if "resistance" in sys.argv:
 
 rule resistance_detailed_table:
     container:
-        singularity_envs["python_r"]   
+        containers["python_r"]   
     input:
         res_files=expand("samples/{sample}/resistance/combined_{sample}.tsv", sample=read_naming.keys()),
     output:

--- a/rules/report_generation/report_resistance.rules
+++ b/rules/report_generation/report_resistance.rules
@@ -37,10 +37,8 @@ def resistance_input(wildcards):
 if "resistance" in sys.argv:
 
     rule report_resistance:
-        conda:
-            containers["python_r"]
         container:
-            "docker://metagenlab/diag-pipeline-python-r:1.1"
+            containers["python_r"]
         input:
             unpack(resistance_input)
         params:

--- a/rules/report_generation/report_virulence.rules
+++ b/rules/report_generation/report_virulence.rules
@@ -8,7 +8,7 @@ if "virulence" in sys.argv:
         rule report_virulence:
             conda:
                 "../../envs/python-r.yml"
-            singularity:
+            container:
                 singularity_envs["python_r"]
             input:
                 qualimap_reports = expand("report/qualimap/{sample}/bwa/{sample}_assembled_genome/qualimapReport.html", sample=read_naming.keys()),
@@ -40,7 +40,7 @@ if "virulence" in sys.argv:
         rule report_virulence:
             conda:
                 "../../envs/python-r.yml"
-            singularity:
+            container:
                 singularity_envs["python_r"]
             input:
                 qualimap_reports = expand("report/qualimap/{sample}/bwa/{sample}_assembled_genome/qualimapReport.html", sample=read_naming.keys()),

--- a/rules/report_generation/report_virulence.rules
+++ b/rules/report_generation/report_virulence.rules
@@ -9,7 +9,7 @@ if "virulence" in sys.argv:
             conda:
                 "../../envs/python-r.yml"
             container:
-                singularity_envs["python_r"]
+                containers["python_r"]
             input:
                 qualimap_reports = expand("report/qualimap/{sample}/bwa/{sample}_assembled_genome/qualimapReport.html", sample=read_naming.keys()),
                 multiqc_assembly = "report/multiqc_assembly/multiqc_report.html",
@@ -41,7 +41,7 @@ if "virulence" in sys.argv:
             conda:
                 "../../envs/python-r.yml"
             container:
-                singularity_envs["python_r"]
+                containers["python_r"]
             input:
                 qualimap_reports = expand("report/qualimap/{sample}/bwa/{sample}_assembled_genome/qualimapReport.html", sample=read_naming.keys()),
                 multiqc_assembly = "report/multiqc_assembly/multiqc_report.html",

--- a/rules/report_generation/report_virulence.rules
+++ b/rules/report_generation/report_virulence.rules
@@ -19,14 +19,14 @@ if "virulence" in sys.argv:
                 contig_gc_depth_file_list = expand("samples/{sample}/quality/mapping/bwa/{sample}_assembled_genome/contig_gc_depth_500bp_high_coverage.tab",
                 sample=read_naming.keys()),
                 low_cov_detail = expand("report/contamination/low_coverage_contigs/{sample}.html", sample=read_naming.keys()),
-		high_cov_fastgs = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
+                high_cov_fastgs = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
                 mash_results = expand('samples/{sample}/contamination/mash/assembly/distances_formated.tsv', sample=read_naming.keys()),
                 mash_detail = expand("report/contamination/mash/assembly/{sample}.html", sample=read_naming.keys()),
                 custom_virulence = expand("report/virulence/custom/{sample}_report.html", sample=read_naming.keys()),
                 custom_virulence_fasta = expand("samples/{sample}/virulence/proteins.fasta", sample=read_naming.keys()),
                 centrifuge_tables = expand("report/contamination/centrifuge/{sample}/centrifuge_kraken_format.txt", sample=read_naming.keys()),
-		rrna_classification_file = "report/contamination/markers/rrna/summary.txt",
-		checkm_table = "report/contamination/checkm/checkm_qualty.tab"
+                rrna_classification_file = "report/contamination/markers/rrna/summary.txt",
+                checkm_table = "report/contamination/checkm/checkm_qualty.tab"
             params:
                 samples = list(read_naming.keys()),
                 sample_table = all_samples,
@@ -48,15 +48,15 @@ if "virulence" in sys.argv:
                 virulence_reports = expand("report/virulence/VFDB/{sample}_report.html", sample=read_naming.keys()),
                 blast_results = expand("samples/{sample}/virulence/VFDB_results_blast.tsv", sample = read_naming.keys()),
                 low_cov_fastas = expand("samples/{sample}/assembly/spades/coverage_filtered/bwa/contigs_500bp_low_coverage.fasta", sample=read_naming.keys()),
-		high_cov_fastgs = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
+                high_cov_fastgs = expand("samples/{sample}/assembly/spades/assembly_graph.fastg", sample=read_naming.keys()),
                 contig_gc_depth_file_list = expand("samples/{sample}/quality/mapping/bwa/{sample}_assembled_genome/contig_gc_depth_500bp_high_coverage.tab",
                 sample=read_naming.keys()),
                 low_cov_detail = expand("report/contamination/low_coverage_contigs/{sample}.html", sample=read_naming.keys()),
                 mash_results = expand('samples/{sample}/contamination/mash/assembly/distances_formated.tsv', sample=read_naming.keys()),
                 mash_detail = expand("report/contamination/mash/assembly/{sample}.html", sample=read_naming.keys()),
                 centrifuge_tables = expand("report/contamination/centrifuge/{sample}/centrifuge_kraken_format.txt", sample=read_naming.keys()),
-		rrna_classification_file = "report/contamination/markers/rrna/summary.txt",
-		checkm_table = "report/contamination/checkm/checkm_qualty.tab"
+                rrna_classification_file = "report/contamination/markers/rrna/summary.txt",
+                checkm_table = "report/contamination/checkm/checkm_qualty.tab"
             params:
                 samples = list(read_naming.keys()),
                 sample_table = all_samples

--- a/rules/report_generation/rgi_docx_report.rules
+++ b/rules/report_generation/rgi_docx_report.rules
@@ -15,7 +15,7 @@ rule combined2rst:
         rgi_files=expand("samples/{sample}/resistance/combined_{sample}.tsv", sample=read_naming.keys()),
         mlst_file="report/typing/mlst/summary.tsv",
         mash_files=expand("samples/{sample}/contamination/mash/assembly/distances_formated.tsv", sample=read_naming.keys()),
-	plasmid_files=expand("samples/{sample}/plasmids/{sample}.tsv", sample=read_naming.keys()),
+        plasmid_files=expand("samples/{sample}/plasmids/{sample}.tsv", sample=read_naming.keys()),
     output:
         "report/resistance/combined_report.rst",
     log:
@@ -30,14 +30,15 @@ rule rgi2rst_per_sample:
         aro_filter=get_aro_filter()
     input:
         rgi_files="samples/{sample}/resistance/combined_{sample}.tsv",
-	plasmid_files=expand("samples/{sample}/plasmids/{sample}.tsv", sample=read_naming.keys()),
+        plasmid_files=expand("samples/{sample}/plasmids/{sample}.tsv", sample=read_naming.keys()),
         mlst_file="report/typing/mlst/summary.tsv",
         mash_files="samples/{sample}/contamination/mash/assembly/distances_formated.tsv",
     output:
         "report/resistance/combined_report_{sample}.rst",
     log:
         logging_folder + "report/resistance/combined_report_{sample}.log"
-    script: "scripts/card_mlst_rst_report.py"
+    script: 
+        "scripts/card_mlst_rst_report.py"
 
 
 

--- a/rules/report_generation/rgi_docx_report.rules
+++ b/rules/report_generation/rgi_docx_report.rules
@@ -8,7 +8,7 @@ def get_aro_filter():
 
 rule combined2rst:
     container:
-        singularity_envs["python_r"]  
+        containers["python_r"]  
     params:
         aro_filter=get_aro_filter()
     input:
@@ -25,7 +25,7 @@ rule combined2rst:
 
 rule rgi2rst_per_sample:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     params:
         aro_filter=get_aro_filter()
     input:
@@ -44,7 +44,7 @@ rule rgi2rst_per_sample:
 
 rule rst2docx:
     container:
-        singularity_envs["pandoc"]   
+        containers["pandoc"]   
     input:
         "{path}.rst",
     output:
@@ -61,7 +61,7 @@ rule rst2docx:
 
 rule tsv2xlsx:
     container:
-        singularity_envs["python_r"]   
+        containers["python_r"]   
     input:
         "{path}.tsv",
     output:

--- a/rules/report_generation/rgi_docx_report.rules
+++ b/rules/report_generation/rgi_docx_report.rules
@@ -7,7 +7,7 @@ def get_aro_filter():
         return []
 
 rule combined2rst:
-    singularity:
+    container:
         singularity_envs["python_r"]  
     params:
         aro_filter=get_aro_filter()
@@ -24,7 +24,7 @@ rule combined2rst:
 
 
 rule rgi2rst_per_sample:
-    singularity:
+    container:
         singularity_envs["python_r"]
     params:
         aro_filter=get_aro_filter()
@@ -42,7 +42,7 @@ rule rgi2rst_per_sample:
 
 
 rule rst2docx:
-    singularity:
+    container:
         singularity_envs["pandoc"]   
     input:
         "{path}.rst",
@@ -59,7 +59,7 @@ rule rst2docx:
 
 
 rule tsv2xlsx:
-    singularity:
+    container:
         singularity_envs["python_r"]   
     input:
         "{path}.tsv",

--- a/rules/report_generation/scripts/report.py
+++ b/rules/report_generation/scripts/report.py
@@ -9,7 +9,7 @@ def checkm_table(checkm_table):
     
     df = pandas.read_csv(checkm_table, delimiter="\t", header=0)
     df = df[["Bin Id","Marker lineage","# markers", "Completeness","Contamination","Strain heterogeneity","0","1","2","3","4","5+"]]
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -46,7 +46,7 @@ def get_rrna_summary_table(raw_table,
     
     header = ["sample", "N.", "expected", "contig", "BBH_taxnonomy", "identity"]
     df = pandas.DataFrame(row_list, columns=header)
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -86,7 +86,7 @@ def get_centrifuge_table(centrifuge_links, sample2scientific_name):
         row_list.append(row)
     header = ["sample", "expected", "taxon 1", "% reads", "taxon 2", "% reads", "taxon 3", "% reads", "detail"]
     df = pandas.DataFrame(row_list, columns=header)
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -136,7 +136,7 @@ def get_mash_table(file_list, mash_detail, sample2scientific_name):
         row_list.append(row)
     header = ["sample", "expected", "score", "sketch", "description", "score", "sketch", "description","score", "sketch", "description", "detail"]
     df = pandas.DataFrame(row_list, columns=header)
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -164,7 +164,7 @@ def get_multiqc_table(assembly_multiqc=False,
     df = pandas.DataFrame(mq_table, columns=header)
 
     # cell content is truncated if colwidth not set to -1
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -276,7 +276,7 @@ def quality_table(low_cov_fastas,
         df = pandas.DataFrame(cov_table, columns=header)
 
         # cell content is truncated if colwidth not set to -1
-        pandas.set_option('display.max_colwidth', -1)
+        pandas.set_option('display.max_colwidth', 1)
 
         df_str = df.to_html(
             index=False,
@@ -314,7 +314,7 @@ def qualimap_table(qualimap_links, self_mapping=False):
     df = pandas.DataFrame(cov_table, columns=header)
 
     # cell content is truncated if colwidth not set to -1
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -354,7 +354,7 @@ def virulence_table(virulence_reports,
     df = pandas.DataFrame(vf_data, columns=header)
 
     # cell content is truncated if colwidth not set to -1
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -382,7 +382,7 @@ def resistance_table(resistance_reports):
 
 
     # cell content is truncated if colwidth not set to -1
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,
@@ -496,7 +496,7 @@ def get_snp_detail_table(snp_link_list, indel_link_list):
     df = pandas.DataFrame(rows, columns=header)
 
     # cell content is truncated if colwidth not set to -1
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,

--- a/rules/report_generation/scripts/report_lowcov_contigs.py
+++ b/rules/report_generation/scripts/report_lowcov_contigs.py
@@ -1,8 +1,7 @@
 
 import pandas
 from Bio import SeqIO
-import report
-from Bio.SeqUtils import GC
+from Bio.SeqUtils import gc_fraction
 import io
 from docutils.core import publish_file, publish_parts
 
@@ -17,21 +16,21 @@ output_file = snakemake.output[0]
 def get_fasta_table(fasta_records):
     header = ["contig",
               "contig_length",
-              "gc content",
+              "gc_fraction content",
               "BLAST"]
 
     rows = []
     for record in records:
         rows.append([record.name,
                     len(record.seq),
-                    GC(record.seq),
+                    gc_fraction(record.seq),
                     '<a href="https://blast.ncbi.nlm.nih.gov/Blast.cgi?ALIGNMENT_VIEW=Pairwise&PROGRAM=blastn&DATABASE=nt&CMD=Put&QUERY=%s"> %s ...</a>' % (record.seq,
                                                   record.seq[0:80])])
 
     df = pandas.DataFrame(rows, columns=header)
 
     # cell content is truncated if colwidth not set to -1
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option('display.max_colwidth', 1)
 
     df_str = df.to_html(
         index=False,

--- a/rules/report_generation/scripts/report_mash.py
+++ b/rules/report_generation/scripts/report_mash.py
@@ -1,23 +1,16 @@
-
 import pandas
 from Bio import SeqIO
-import report
-from Bio.SeqUtils import GC
 import io
-from docutils.core import publish_file, publish_parts
+from docutils.core import publish_file
 import re
 
 link = snakemake.input[0]
 output_file = snakemake.output[0]
 expected_genus = snakemake.params["expected_genus"]
 
+
 def get_mash_table(link):
-    header = ["score",
-              "sketch",
-               "n",
-              "e-value",
-              "accession",
-              "description"]
+    header = ["score", "sketch", "n", "e-value", "accession", "description"]
 
     table = pandas.read_csv(link, delimiter="\t", names=header)
     table = table.sort_values(table.columns[0], ascending=False)
@@ -29,22 +22,20 @@ def get_mash_table(link):
         accession = re.findall("(GCF_[0-9]*\.[0-9]+)_.*", row["accession"])[0]
         description = re.sub("\[[0-9]+ seqs\] ", "", row["description"])
 
-
-        data = [score,
-                sketch,
-                evalue,
-                '<a href="https://www.ncbi.nlm.nih.gov/assembly/%s/">%s</a>' % (accession, accession),
-                ' '.join(description.split(" ")[1:])[0:80]]
+        data = [
+            score,
+            sketch,
+            evalue,
+            '<a href="https://www.ncbi.nlm.nih.gov/assembly/%s/">%s</a>'
+            % (accession, accession),
+            " ".join(description.split(" ")[1:])[0:80],
+        ]
         rows.append(data)
-    header = ["score",
-              "sketch",
-              "e-value",
-              "accession",
-              "description"]
+    header = ["score", "sketch", "e-value", "accession", "description"]
     df = pandas.DataFrame(rows, columns=header)
 
     # cell content is truncated if colwidth not set to -1
-    pandas.set_option('display.max_colwidth', -1)
+    pandas.set_option("display.max_colwidth", 1)
 
     df_str = df.to_html(
         index=False,
@@ -52,7 +43,8 @@ def get_mash_table(link):
         classes=["dataTable"],
         table_id="mash_table",
         escape=False,
-        border=0)
+        border=0,
+    )
 
     return df_str.replace("\n", "\n" + 10 * " ")
 
@@ -69,7 +61,8 @@ STYLE = """
     </style>
     """
 
-SCRIPT = """
+SCRIPT = (
+    """
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
@@ -113,9 +106,9 @@ SCRIPT = """
     } );
     </script>
 
-    """ % expected_genus
-
-
+    """
+    % expected_genus
+)
 
 
 contig_table = get_mash_table(link)

--- a/rules/report_generation/scripts/report_resistance.py
+++ b/rules/report_generation/scripts/report_resistance.py
@@ -1,15 +1,8 @@
-
-# from snakemake.utils import report
-
-# with open(input[0]) as vcf:
-#    n_calls = sum(1 for l in vcf if not l.startswith("#"))
-# n_samples = list(read_naming.keys()
 import pandas
 from report import quality_table, resistance_table
 import report
 import io
-from docutils.core import publish_file, publish_parts
-from docutils.parsers.rst import directives
+from docutils.core import publish_file
 from Bio import SeqIO
 
 multiqc_assembly = snakemake.input["multiqc_assembly"]

--- a/rules/report_generation/snps.rules
+++ b/rules/report_generation/snps.rules
@@ -55,7 +55,7 @@ def vcf_ref(wildcards):
 rule generate_snps_html_report:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         # samples/TATRas-control/snps/gatk_gvcfs/TATRas-control_assembled_genome/bwa/freq.vcf
@@ -74,7 +74,7 @@ rule generate_snps_html_report:
 rule generate_deletion_html_report:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         deletion_bed = "samples/{sample}/indel/{mapping_method}/{reference}/indel.bed",

--- a/rules/report_generation/snps.rules
+++ b/rules/report_generation/snps.rules
@@ -56,7 +56,7 @@ rule generate_snps_html_report:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         # samples/TATRas-control/snps/gatk_gvcfs/TATRas-control_assembled_genome/bwa/freq.vcf
         # typing/gatk_gvcfs/full_genome_TATRas-control_assembled_genome/bwa/all_samples_snp.vcf
@@ -75,7 +75,7 @@ rule generate_deletion_html_report:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         deletion_bed = "samples/{sample}/indel/{mapping_method}/{reference}/indel.bed",
         gbk_file = gbk_ref

--- a/rules/taxonomy/gtdbtk.rules
+++ b/rules/taxonomy/gtdbtk.rules
@@ -2,7 +2,7 @@
 
 rule gtdb_classify_wf:
     container:
-        singularity_envs["gtdbtk"]
+        containers["gtdbtk"]
     input:
         expand("report/genomes/{sample}.faa", sample=read_naming.keys())
     output:

--- a/rules/taxonomy/gtdbtk.rules
+++ b/rules/taxonomy/gtdbtk.rules
@@ -1,7 +1,7 @@
 
 
 rule gtdb_classify_wf:
-    singularity:
+    container:
         singularity_envs["gtdbtk"]
     input:
         expand("report/genomes/{sample}.faa", sample=read_naming.keys())

--- a/rules/typing/mentalist.rules
+++ b/rules/typing/mentalist.rules
@@ -3,7 +3,7 @@ rule determine_mlst_from_trimmed_reads:
     conda:
         "../../envs/mentalist.yml"
     container:
-        singularity_envs["mentalist"]
+        containers["mentalist"]
     input:
         fastq1 = "samples/{sample}/reads/trimmed/R1_paired.fastq",
         fastq2 = "samples/{sample}/reads/trimmed/R2_paired.fastq",

--- a/rules/typing/mentalist.rules
+++ b/rules/typing/mentalist.rules
@@ -2,7 +2,7 @@
 rule determine_mlst_from_trimmed_reads:
     conda:
         "../../envs/mentalist.yml"
-    singularity:
+    container:
         singularity_envs["mentalist"]
     input:
         fastq1 = "samples/{sample}/reads/trimmed/R1_paired.fastq",

--- a/rules/typing/mlst.rules
+++ b/rules/typing/mlst.rules
@@ -2,7 +2,7 @@ rule determine_mlst:
     conda:
         "../../envs/mlst.yml"
     container:
-        singularity_envs["mlst"]
+        containers["mlst"]
     input:
         fasta = "samples/{sample}/annotation/{sample}.fna",
     output:
@@ -27,7 +27,7 @@ rule determine_mlst_reference_genome:
     conda:
         "../../envs/mlst.yml"
     container:
-        singularity_envs["mlst"]
+        containers["mlst"]
     input:
         genome = "references/{ref}/genome_fna.fna"
     output:
@@ -41,7 +41,7 @@ rule generate_xlsx_file_from_mlst_results:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         "report/typing/mlst/{file}.tsv"
     output:

--- a/rules/typing/mlst.rules
+++ b/rules/typing/mlst.rules
@@ -1,7 +1,7 @@
 rule determine_mlst:
     conda:
         "../../envs/mlst.yml"
-    singularity:
+    container:
         singularity_envs["mlst"]
     input:
         fasta = "samples/{sample}/annotation/{sample}.fna",
@@ -26,7 +26,7 @@ rule merge_mlst_from_all_samples:
 rule determine_mlst_reference_genome:
     conda:
         "../../envs/mlst.yml"
-    singularity:
+    container:
         singularity_envs["mlst"]
     input:
         genome = "references/{ref}/genome_fna.fna"
@@ -40,7 +40,7 @@ rule determine_mlst_reference_genome:
 rule generate_xlsx_file_from_mlst_results:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         "report/typing/mlst/{file}.tsv"

--- a/rules/typing/saureus_spa.rules
+++ b/rules/typing/saureus_spa.rules
@@ -1,5 +1,5 @@
 rule determine_spa:
-    singularity:
+    container:
         singularity_envs["python_r"]
     input:
         fasta = "samples/{sample}/annotation/{sample}.fsa",

--- a/rules/typing/saureus_spa.rules
+++ b/rules/typing/saureus_spa.rules
@@ -1,6 +1,6 @@
 rule determine_spa:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     input:
         fasta = "samples/{sample}/annotation/{sample}.fsa",
         spa_repeats = "../../data/spa/sparepeats.fasta",

--- a/rules/typing/snp_distance.rules
+++ b/rules/typing/snp_distance.rules
@@ -2,7 +2,7 @@ rule distance_columns_to_matrix:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]    
+        containers["python_r"]    
     params:
         samples = list(read_naming.keys())
     input:
@@ -18,7 +18,7 @@ rule compute_minimum_spanning_tree_with_st:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]   
+        containers["python_r"]   
     params:
         threshold = config["snp_threshold"],
         mst_size = config["minimum_spanning_tree_size"],
@@ -37,7 +37,7 @@ rule compute_minimum_spanning_tree_no_st:
     conda:
         "../../envs/python-r.yml"
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     params:
         threshold=config["snp_threshold"],
         mst_size = config["minimum_spanning_tree_size"],  

--- a/rules/typing/snp_distance.rules
+++ b/rules/typing/snp_distance.rules
@@ -1,7 +1,7 @@
 rule distance_columns_to_matrix:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]    
     params:
         samples = list(read_naming.keys())
@@ -17,7 +17,7 @@ rule distance_columns_to_matrix:
 rule compute_minimum_spanning_tree_with_st:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]   
     params:
         threshold = config["snp_threshold"],
@@ -36,7 +36,7 @@ rule compute_minimum_spanning_tree_with_st:
 rule compute_minimum_spanning_tree_no_st:
     conda:
         "../../envs/python-r.yml"
-    singularity:
+    container:
         singularity_envs["python_r"]
     params:
         threshold=config["snp_threshold"],

--- a/rules/vcf_manipulation/calculate_differences.rules
+++ b/rules/vcf_manipulation/calculate_differences.rules
@@ -1,7 +1,7 @@
 rule calculate_pairwise_distances_by_type:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         joint_genotype_vcf="{any_analysis}/all_samples_{type}.vcf.gz",
@@ -17,7 +17,7 @@ rule calculate_pairwise_distances_by_type:
 rule get_pairwise_snps_positions_by_type:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         joint_genotype_vcf="{any_analysis}/all_samples_{type}.vcf.gz",
@@ -34,7 +34,7 @@ rule get_pairwise_snps_positions_by_type:
 rule calculate_distance_with_ref_by_type:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"] 
     input:
         joint_genotype_vcf="{any_analysis}/all_samples_{type}.vcf.gz",

--- a/rules/vcf_manipulation/calculate_differences.rules
+++ b/rules/vcf_manipulation/calculate_differences.rules
@@ -2,7 +2,7 @@ rule calculate_pairwise_distances_by_type:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         joint_genotype_vcf="{any_analysis}/all_samples_{type}.vcf.gz",
         joint_genotype_vcf_tbi="{any_analysis}/all_samples_{type}.vcf.gz.tbi",
@@ -18,7 +18,7 @@ rule get_pairwise_snps_positions_by_type:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         joint_genotype_vcf="{any_analysis}/all_samples_{type}.vcf.gz",
         joint_genotype_vcf_tbi="{any_analysis}/all_samples_{type}.vcf.gz.tbi",
@@ -35,7 +35,7 @@ rule calculate_distance_with_ref_by_type:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"] 
+        containers["bcftools"] 
     input:
         joint_genotype_vcf="{any_analysis}/all_samples_{type}.vcf.gz",
         joint_genotype_vcf_tbi="{any_analysis}/all_samples_{type}.vcf.gz.tbi",

--- a/rules/vcf_manipulation/create_alignment_for_phylogeny.rules
+++ b/rules/vcf_manipulation/create_alignment_for_phylogeny.rules
@@ -1,7 +1,7 @@
 rule merge_multiallelic_by_sample:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         vcf="typing/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/all_samples_snp.vcf.gz",
@@ -17,7 +17,7 @@ rule merge_multiallelic_by_sample:
 rule extract_alternative_positions_and_unknown_positions:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]   
     input:
         merged_multi = "samples/{sample}/snps/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/snps.vcf.gz",
@@ -35,7 +35,7 @@ rule extract_alternative_positions_and_unknown_positions:
 rule create_consensus_sequence_by_sample:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]   
     input:
         alt="samples/{sample}/snps/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/alternative_snp.vcf.gz",

--- a/rules/vcf_manipulation/create_alignment_for_phylogeny.rules
+++ b/rules/vcf_manipulation/create_alignment_for_phylogeny.rules
@@ -2,7 +2,7 @@ rule merge_multiallelic_by_sample:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         vcf="typing/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/all_samples_snp.vcf.gz",
         vcf_tbi="typing/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/all_samples_snp.vcf.gz.tbi",
@@ -18,7 +18,7 @@ rule extract_alternative_positions_and_unknown_positions:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]   
+        containers["bcftools"]   
     input:
         merged_multi = "samples/{sample}/snps/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/snps.vcf.gz",
         merged_multi_tbi = "samples/{sample}/snps/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/snps.vcf.gz.tbi",
@@ -36,7 +36,7 @@ rule create_consensus_sequence_by_sample:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]   
+        containers["bcftools"]   
     input:
         alt="samples/{sample}/snps/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/alternative_snp.vcf.gz",
         alt_tbi="samples/{sample}/snps/{snp_caller}/{core_genome_or_full_genome}/{mapping_method}/alternative_snp.vcf.gz.tbi",

--- a/rules/vcf_manipulation/filtering.rules
+++ b/rules/vcf_manipulation/filtering.rules
@@ -2,7 +2,7 @@ rule decompose_multiallelics_and_normalize:
     conda:
         "../../envs/vt.yml"
     container:
-        singularity_envs["vt"]   
+        containers["vt"]   
     input:
         raw="typing/{snp_caller}/full_genome_{ref}/{mapping_method}/raw/all_samples.vcf.gz",
         raw_tbi="typing/{snp_caller}/full_genome_{ref}/{mapping_method}/raw/all_samples.vcf.gz",
@@ -22,7 +22,7 @@ rule filter_on_coverage:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]   
+        containers["bcftools"]   
     input:
         decomposed="typing/{snp_caller}/full_genome_{ref}/{mapping_method}/filtering/decomposed_normalized.vcf",
     output:
@@ -36,7 +36,7 @@ rule filter_on_frequency_per_sample:
     params:
         min_alt=minimum_alternate_frac,
     container:
-        singularity_envs["bcftools"]   
+        containers["bcftools"]   
     conda:
         "../../envs/bcftools.yml",
     input:
@@ -52,7 +52,7 @@ rule extract_allele_by_type_from_gatk_gvcfs:
     conda:
         "../../envs/gatk.yml"
     container:
-        singularity_envs["gatk4"] 
+        containers["gatk4"] 
     input:
         joint_genotype_vcf="typing/gatk_gvcfs/full_genome_{ref}/{mapping_method}/filtering/freq_cov_decomposed_normalized.vcf.gz",
         joint_genotype_vcf_tbi="typing/gatk_gvcfs/full_genome_{ref}/{mapping_method}/filtering/freq_cov_decomposed_normalized.vcf.gz.tbi",
@@ -70,7 +70,7 @@ rule extract_allele_by_type_from_freebayes_joint_genotyping:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]   
+        containers["bcftools"]   
     input:
         joint_genotype_vcf="typing/freebayes_joint_genotyping/full_genome_{ref}/{mapping_method}/filtering/freq_cov_decomposed_normalized.vcf.gz",
         joint_genotype_vcf_tbi="typing/freebayes_joint_genotyping/full_genome_{ref}/{mapping_method}/filtering/freq_cov_decomposed_normalized.vcf.gz.tbi",
@@ -87,7 +87,7 @@ rule extract_core_genome_parsnp:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         vcf_mutation_type = "typing/{snp_caller}/full_genome_{ref}/{mapping_method}/all_samples_{type}.vcf.gz",
         vcf_mutation_type_tbi = "typing/{snp_caller}/full_genome_{ref}/{mapping_method}/all_samples_{type}.vcf.gz.tbi",

--- a/rules/vcf_manipulation/filtering.rules
+++ b/rules/vcf_manipulation/filtering.rules
@@ -1,7 +1,7 @@
 rule decompose_multiallelics_and_normalize:
     conda:
         "../../envs/vt.yml"
-    singularity:
+    container:
         singularity_envs["vt"]   
     input:
         raw="typing/{snp_caller}/full_genome_{ref}/{mapping_method}/raw/all_samples.vcf.gz",
@@ -21,7 +21,7 @@ rule filter_on_coverage:
         min_cov=minimum_coverage,
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]   
     input:
         decomposed="typing/{snp_caller}/full_genome_{ref}/{mapping_method}/filtering/decomposed_normalized.vcf",
@@ -35,7 +35,7 @@ rule filter_on_coverage:
 rule filter_on_frequency_per_sample:
     params:
         min_alt=minimum_alternate_frac,
-    singularity:
+    container:
         singularity_envs["bcftools"]   
     conda:
         "../../envs/bcftools.yml",
@@ -51,7 +51,7 @@ rule filter_on_frequency_per_sample:
 rule extract_allele_by_type_from_gatk_gvcfs:
     conda:
         "../../envs/gatk.yml"
-    singularity:
+    container:
         singularity_envs["gatk4"] 
     input:
         joint_genotype_vcf="typing/gatk_gvcfs/full_genome_{ref}/{mapping_method}/filtering/freq_cov_decomposed_normalized.vcf.gz",
@@ -69,7 +69,7 @@ rule extract_allele_by_type_from_gatk_gvcfs:
 rule extract_allele_by_type_from_freebayes_joint_genotyping:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]   
     input:
         joint_genotype_vcf="typing/freebayes_joint_genotyping/full_genome_{ref}/{mapping_method}/filtering/freq_cov_decomposed_normalized.vcf.gz",
@@ -86,7 +86,7 @@ rule extract_allele_by_type_from_freebayes_joint_genotyping:
 rule extract_core_genome_parsnp:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         vcf_mutation_type = "typing/{snp_caller}/full_genome_{ref}/{mapping_method}/all_samples_{type}.vcf.gz",

--- a/rules/vcf_manipulation/indexing.rules
+++ b/rules/vcf_manipulation/indexing.rules
@@ -2,7 +2,7 @@ rule compress_vcf:
     conda:
         "../../envs/htslib.yml"
     container:
-        singularity_envs["htslib"]   
+        containers["htslib"]   
     input:
         "{any_vcf}.{vcf_or_bed}",
     output:
@@ -14,7 +14,7 @@ rule compress_vcf:
 
 rule index_vcf_bed:
     container:
-        singularity_envs["htslib"]  
+        containers["htslib"]  
     conda:
         "../../envs/htslib.yml"
     input:
@@ -30,7 +30,7 @@ rule sort_vcf:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["htslib"]  
+        containers["htslib"]  
     input:
         "{any_vcf}.vcf.gz",
     output:

--- a/rules/vcf_manipulation/indexing.rules
+++ b/rules/vcf_manipulation/indexing.rules
@@ -1,7 +1,7 @@
 rule compress_vcf:
     conda:
         "../../envs/htslib.yml"
-    singularity:
+    container:
         singularity_envs["htslib"]   
     input:
         "{any_vcf}.{vcf_or_bed}",
@@ -13,7 +13,7 @@ rule compress_vcf:
         """
 
 rule index_vcf_bed:
-    singularity:
+    container:
         singularity_envs["htslib"]  
     conda:
         "../../envs/htslib.yml"
@@ -29,7 +29,7 @@ rule index_vcf_bed:
 rule sort_vcf:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["htslib"]  
     input:
         "{any_vcf}.vcf.gz",

--- a/rules/vcf_manipulation/splitting_merging.rules
+++ b/rules/vcf_manipulation/splitting_merging.rules
@@ -1,7 +1,7 @@
 rule extract_sample_entry_from_vcf:
     conda:
         "../../envs/bcftools.yml",
-    singularity:
+    container:
         singularity_envs["bcftools"]  
     input:
         vcf_cov="typing/{snp_caller}/full_genome_{ref}/{mapping_method}/filtering/cov_decomposed_normalized.vcf",
@@ -15,7 +15,7 @@ rule extract_sample_entry_from_vcf:
 rule merge_all_samples_entries_into_vcf:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]   
     input:
         vfcs=expand("samples/{sample}/snps/{{snp_caller}}/{{ref}}/{{mapping_method}}/freq.vcf.gz", sample=list(read_naming.keys())),
@@ -37,7 +37,7 @@ rule merge_all_samples_entries_into_vcf:
 rule merge_all_vcf_freebayes_first_pass:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]   
     input:
         vfcs = expand("samples/{sample}/typing/freebayes/first_pass/full_genome_{{ref}}/{{mapping_method}}/genotyping.vcf.gz", sample=list(read_naming.keys())),
@@ -52,7 +52,7 @@ rule merge_all_vcf_freebayes_first_pass:
 rule merge_freebayes_second_pass:
     conda:
         "../../envs/bcftools.yml"
-    singularity:
+    container:
         singularity_envs["bcftools"]    
     input:
         vfcs = expand("samples/{sample}/typing/freebayes/second_pass/full_genome_{{ref}}/{{mapping_method}}/genotyping.vcf.gz", sample=list(read_naming.keys())),

--- a/rules/vcf_manipulation/splitting_merging.rules
+++ b/rules/vcf_manipulation/splitting_merging.rules
@@ -2,7 +2,7 @@ rule extract_sample_entry_from_vcf:
     conda:
         "../../envs/bcftools.yml",
     container:
-        singularity_envs["bcftools"]  
+        containers["bcftools"]  
     input:
         vcf_cov="typing/{snp_caller}/full_genome_{ref}/{mapping_method}/filtering/cov_decomposed_normalized.vcf",
     output:
@@ -16,7 +16,7 @@ rule merge_all_samples_entries_into_vcf:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]   
+        containers["bcftools"]   
     input:
         vfcs=expand("samples/{sample}/snps/{{snp_caller}}/{{ref}}/{{mapping_method}}/freq.vcf.gz", sample=list(read_naming.keys())),
         vfcs_tbi=expand("samples/{sample}/snps/{{snp_caller}}/{{ref}}/{{mapping_method}}/freq.vcf.gz.tbi", sample=list(read_naming.keys())),
@@ -38,7 +38,7 @@ rule merge_all_vcf_freebayes_first_pass:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]   
+        containers["bcftools"]   
     input:
         vfcs = expand("samples/{sample}/typing/freebayes/first_pass/full_genome_{{ref}}/{{mapping_method}}/genotyping.vcf.gz", sample=list(read_naming.keys())),
         vfcs_tbi = expand("samples/{sample}/typing/freebayes/first_pass/full_genome_{{ref}}/{{mapping_method}}/genotyping.vcf.gz.tbi", sample=list(read_naming.keys())),
@@ -53,7 +53,7 @@ rule merge_freebayes_second_pass:
     conda:
         "../../envs/bcftools.yml"
     container:
-        singularity_envs["bcftools"]    
+        containers["bcftools"]    
     input:
         vfcs = expand("samples/{sample}/typing/freebayes/second_pass/full_genome_{{ref}}/{{mapping_method}}/genotyping.vcf.gz", sample=list(read_naming.keys())),
         vfcs_tbi = expand("samples/{sample}/typing/freebayes/second_pass/full_genome_{{ref}}/{{mapping_method}}/genotyping.vcf.gz.tbi", sample=list(read_naming.keys())),

--- a/workflows/check_resistance_databases.rules
+++ b/workflows/check_resistance_databases.rules
@@ -9,7 +9,7 @@ reference_assembly_for_resistance["Mycobacterium_tuberculosis"] = "538048"
 rule create_reference_lists_from_databases:
     conda:
         "../envs/pandas-openpyxl-pronto-xlrd.yml"
-    singularity:
+    container:
         "docker://metagenlab/diag-pipeline-python-r:1.1"
     input:
         miotto = "resistance_db/" + species + "/mutations/miotto_high_moderate_minimum_confidence_annotated.tsv",
@@ -33,7 +33,7 @@ rule create_reference_lists_from_databases:
 rule check_annotated_mutations_from_database_and_create_bed_file:
     conda:
         "../envs/pandas-openpyxl-pronto-xlrd.yml"
-    singularity:
+    container:
         "docker://metagenlab/diag-pipeline-python-r:1.1"
     input:
         db = "resistance_db/" + species + "/mutations/{db}.tsv",

--- a/workflows/core_genomes/make_enterobase.rules
+++ b/workflows/core_genomes/make_enterobase.rules
@@ -1,7 +1,7 @@
 import pandas
 import yaml
 
-singularity_envs = yaml.safe_load(open(os.path.join(workflow.basedir,  "../../envs/singularity/envs.yml"), 'r'))
+containers = yaml.safe_load(open(os.path.join(workflow.basedir,  "../../envs/singularity/envs.yml"), 'r'))
 
 include:
     "../logging.rules"
@@ -23,7 +23,7 @@ rule get_schema_from_enterobase:
 
 rule fetch_gene_entries_from_locus_tag:
     container:
-        singularity_envs["python_r"]
+        containers["python_r"]
     conda:
         "../../envs/biopython.yml"
     input:
@@ -38,7 +38,7 @@ rule fetch_gene_entries_from_locus_tag:
 
 rule merge_bed_file:
     container:
-        singularity_envs["bedtools"]
+        containers["bedtools"]
     conda:
         "../../envs/bedtools.yml"
     input:

--- a/workflows/core_genomes/make_enterobase.rules
+++ b/workflows/core_genomes/make_enterobase.rules
@@ -22,7 +22,7 @@ rule get_schema_from_enterobase:
         """
 
 rule fetch_gene_entries_from_locus_tag:
-    singularity:
+    container:
         singularity_envs["python_r"]
     conda:
         "../../envs/biopython.yml"
@@ -36,8 +36,8 @@ rule fetch_gene_entries_from_locus_tag:
         "../../rules/core_genome/scripts/parse_gff_extract_locus_tags.py"
 
 
-rule merbe_bed_file:
-    singularity:
+rule merge_bed_file:
+    container:
         singularity_envs["bedtools"]
     conda:
         "../../envs/bedtools.yml"

--- a/workflows/core_genomes/make_parsnp.rules
+++ b/workflows/core_genomes/make_parsnp.rules
@@ -1,6 +1,6 @@
 pipeline_path = workflow.basedir + "/../../"
 
-singularity_envs = yaml.safe_load(open(os.path.join(workflow.basedir,  "../../envs/singularity/envs.yml"), 'r'))
+containers = yaml.safe_load(open(os.path.join(workflow.basedir,  "../../envs/singularity/envs.yml"), 'r'))
 
 include:
     "../logging.rules"

--- a/workflows/core_genomes/make_ridom.rules
+++ b/workflows/core_genomes/make_ridom.rules
@@ -1,7 +1,7 @@
 import pandas
 import yaml
 
-singularity_envs = yaml.safe_load(open(os.path.join(workflow.basedir,  "../../envs/singularity/envs.yml"), 'r'))
+containers = yaml.safe_load(open(os.path.join(workflow.basedir,  "../../envs/singularity/envs.yml"), 'r'))
 
 include:
     "../logging.rules"

--- a/workflows/full_pipeline.rules
+++ b/workflows/full_pipeline.rules
@@ -7,11 +7,11 @@ import os
 PIPELINE_VERSION = "2.8.0"
 
 
-if "--use-singularity" in sys.argv:
+if "--use-singularity" in sys.argv or "--use-apptainer" in sys.argv:
     worflow_path = workflow.snakefile.split("workflows/full_pipeline.rules")[0]
     workflow.deployment_settings.apptainer_args += f' -B {worflow_path}:{worflow_path}'
 
-    singularity_envs = yaml.safe_load(open(os.path.join(workflow.basedir,  "../envs/singularity/envs.yml"), 'r'))
+    containers = yaml.safe_load(open(os.path.join(workflow.basedir,  "../envs/containers/envs.yml"), 'r'))
 
     
 include:

--- a/workflows/full_pipeline.rules
+++ b/workflows/full_pipeline.rules
@@ -9,7 +9,7 @@ PIPELINE_VERSION = "2.8.0"
 
 if "--use-singularity" in sys.argv:
     worflow_path = workflow.snakefile.split("workflows/full_pipeline.rules")[0]
-    workflow.singularity_args += f' -B {worflow_path}:{worflow_path}'
+    workflow.deployment_settings.apptainer_args += f' -B {worflow_path}:{worflow_path}'
 
     singularity_envs = yaml.safe_load(open(os.path.join(workflow.basedir,  "../envs/singularity/envs.yml"), 'r'))
 


### PR DESCRIPTION
# Summary 
Small release to work with latest snakemake and apptainer versions

## `Changes`
* d9aa7b78f881979a1b4c4be5f912c44c9a592db5 Renamed singularity rule directive to container
* 23df594cf7bdeb0ed550190f6f23331b5f5249ff 96195e2856c913717533c6cca7701ce6bd828929 Updated python-r docker
* eacc7a3362683f6a6e5d9d5b64a8e5dbb183e4ca Removed commented rule (prepare_low_coverage_contigs_report)
* 7c30357bb2099ac1384062c19c42e39c509d8e8c Replaced dynamic with checkpoint
* 336a5378367f5893b0cd99af0285d7ae0d2dbf38 eb575f13693134c662879aab63f99c8559a9b2d6 Added shell triple quotes for awk command visibility 
* 6ccf75b6861f1f296ed909dfd0d21c1b5b60058b Updated checkM container
* 97aa260af3c98bc183fa1bc6412c5c081223b283 Imrpoved plot_gene_presence_heatmap.R formatting
## `Fixes`
* 92e29ddd6cad7a36b035208ae968de824f609513 f64f98123734c80b8f7f6effca477146483e0fb1 e920fc83dd33d87dd3e157d15ab2bb0ad5b0af9f Fixed tabs and indentations
* 5573ebbfe3cb619a546fca459f3f206f6d866b11 Fixed singularity attribute error
* 3ebf8de5e3f88dd71f0a4920ddf1d984e7b58287 Fixed conda attribute error
* 8ce1d2992a03a21ee35274941fd142353c0e0706 Fixed centrifuge conda env
* 227f21400e06d191c83143fa37c35f145cf6287a Fixed path to bakta db
* 36407298f4a4dd1ce98a51f93011cfd1b3b6aced 53620381275e94c26b892fc022468d69a9dccb9e Fixed pandas colwidth to 1 
* 1c1a78c4c06e73726b86f1ee0d807e28c908bded 621b4205d7fa3c73b466809a155733573f1f52af Replaced biopython's `GC` to `gc_fraction`
* bdf70ce5b6c6c2e7d7e4db9acee182acf091c1a7 Fixed conda env in report_resistance
